### PR TITLE
Fix agg_method reference in docstring

### DIFF
--- a/vassoura/autocorrelacao.py
+++ b/vassoura/autocorrelacao.py
@@ -63,9 +63,9 @@ def compute_panel_acf(
         mensais.
     min_periods : int
         Comprimento mínimo de histórico para considerar o contrato.
-    agg : {"mean", "median", "weighted"}
-        Como agregar a ACF entre contratos. "weighted" usa o inverso do
-        comprimento da série como peso.
+    agg_method : {"mean", "median", "weighted"}
+        Método de agregação da ACF entre contratos. "weighted" usa o inverso
+        do comprimento da série como peso.
 
     Retorna
     -------

--- a/vassoura/autocorrelacao.py
+++ b/vassoura/autocorrelacao.py
@@ -102,9 +102,9 @@ def compute_panel_acf(
     for lag, values in lag_vals.items():
         if not values:
             continue
-        if agg_method  == "median":
+        if agg_method == "median":
             agg_val = float(np.median(values))
-        elif agg_method  == "weighted":
+        elif agg_method == "weighted":
             # peso = 1/len(series); já é parecido pois cada list entry vem de serie >= min_periods
             weights = [1 / len(v) if not isinstance(v, list) else 1 for v in values]
             agg_val = float(np.average(values, weights=weights))


### PR DESCRIPTION
## Summary
- fix parameter name in `compute_panel_acf` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68425eb0bc7883218881c96ef39f3f02