### PR TITLE
Fix weighted ACF aggregation

### DIFF
--- a/vassoura/autocorrelacao.py
+++ b/vassoura/autocorrelacao.py
@@ -63,9 +63,11 @@ def compute_panel_acf(
         mensais.
     min_periods : int
         Comprimento mínimo de histórico para considerar o contrato.
-    agg : {"mean", "median", "weighted"}
+    agg_method : {"mean", "median", "weighted"}
         Como agregar a ACF entre contratos. "weighted" usa o inverso do
         comprimento da série como peso.
+    verbose : bool
+        Exibe mensagens de depuração caso ``True``.
 
     Retorna
     -------


### PR DESCRIPTION
## Summary
- keep series length when gathering contract ACFs
- weight ACF aggregation by inverse length when `agg_method="weighted"`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68425eabfc70832196d0d867fbbbf69c