### PR TITLE
Fix typo in relatorio docstring

### DIFF
--- a/vassoura/relatorio.py
+++ b/vassoura/relatorio.py
@@ -98,7 +98,7 @@ def generate_report(
     df : pandas.DataFrame
         DataFrame original.
     output_path : str | Path
-        Caminho onde gramhar o arquivo de saída.
+        Caminho onde gravar o arquivo de saída.
     target_col : str | None
         Nome da coluna target. Será excluída das análises se include_target=False.
     corr_method : {"auto", "pearson", "spearman", "cramer"}


### PR DESCRIPTION
## Summary
- fix typo in relatorio output path docstring

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68425ea8d4c88321acaf14496de26ddf