### PR TITLE
Atualiza docstring do compute_panel_acf

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ pyproject.toml             # Configuração do projeto
 
 * Calcula **ACF por contrato** (identificado por `id_col`) reindexando meses faltantes (`time_col` formatado como `YYYYMM`).
 * Ignora contratos com menos de `min_periods` meses.
-* Agrega ACF via: média (`mean`), mediana (`median`) ou ponderada (`weighted`).
+* Agrega ACF via: média (`mean`), mediana (`median`) ou ponderada (`weighted`,
+  usando o comprimento da série como peso).
 * Gera gráfico de barras horizontais com rótulos e linhas de confiança.
 
 ### 6. Analisador de Autocorrelação (`analisar_autocorrelacao`)


### PR DESCRIPTION
## Summary
- clarify weighting description in autocorrelacao docs
- weight panel ACF by series length instead of its inverse
- document new behaviour in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684265bf7a008321ad8689e7d8c82628