### PR TITLE
Add PD behavior dataset utilities

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,0 +1,4 @@
+Este diretório armazena datasets de exemplo utilizados nos notebooks.
+O arquivo `pd_behavior_example.parquet` seria gerado pela função
+`vassoura.criar_dataset_pd_behavior` mas não é incluído aqui por
+limitações de ambiente.

--- a/vassoura/__init__.py
+++ b/vassoura/__init__.py
@@ -1,4 +1,9 @@
-from .utils import search_dtypes, suggest_corr_method, figsize_from_matrix
+from .utils import (
+    search_dtypes,
+    suggest_corr_method,
+    figsize_from_matrix,
+    criar_dataset_pd_behavior,
+)
 from .correlacao import compute_corr_matrix, plot_corr_heatmap
 from .vif import compute_vif, remove_high_vif
 from .limpeza import clean
@@ -10,6 +15,7 @@ __all__ = [
     "search_dtypes",
     "suggest_corr_method",
     "figsize_from_matrix",
+    "criar_dataset_pd_behavior",
     "compute_corr_matrix",
     "plot_corr_heatmap",
     "compute_vif",

--- a/vassoura/examples/3_vassoura_session_pd_behavior.ipynb
+++ b/vassoura/examples/3_vassoura_session_pd_behavior.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Exemplo com VassouraSession e dataset PD Behavior",
+    "\n",
+    "Este notebook demonstra como carregar o dataset `pd_behavior_example.parquet`",
+    " e aplicar a classe `VassouraSession`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from vassoura.core import VassouraSession\n",
+    "import vassoura as vs\n",
+    "\n",
+    "# Carregar dataset de exemplo\n",
+    "df = pd.read_parquet('datasets/pd_behavior_example.parquet')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vsess = VassouraSession(\n",
+    "    df,\n",
+    "    target_col='ever90m12',\n",
+    "    heuristics=['corr', 'vif'],\n",
+    "    thresholds={'corr': 0.9, 'vif': 10},\n",
+    ")\n",
+    "df_clean = vsess.run()\n",
+    "df_clean.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Gera relat\u00f3rio resumido\n",
+    "vsess.generate_report('example_report.html')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `criar_dataset_pd_behavior` helper to generate a PD dataset
- expose helper through package API
- document example datasets folder
- add example notebook showing usage of `VassouraSession`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68430225ea548321a945b8d5199afd86