### PR TITLE
Add fractional removal steps for corr and VIF

### DIFF
--- a/vassoura/relatorio.py
+++ b/vassoura/relatorio.py
@@ -85,6 +85,8 @@ def generate_report(
     remove_ids: bool = False,
     id_patterns: Optional[List[str]] = None,
     max_vif_iter: int = 20,
+    n_steps: int | None = None,
+    vif_n_steps: int = 1,
     heatmap_labels: bool = True,
     heatmap_base_size: float = 0.6,
     verbose: bool = True,
@@ -113,6 +115,10 @@ def generate_report(
         Parâmetros para `search_dtypes`.
     max_vif_iter : int
         Número máximo de iterações no filtro de VIF.
+    n_steps : int | None
+        Passos fracionados para remoção por correlação.
+    vif_n_steps : int
+        Passos fracionados para remoção por VIF.
     heatmap_labels : bool
         Se True, exibe anotações numéricas (valores) no heatmap; caso False, anotações são omitidas.
     heatmap_base_size : float
@@ -205,6 +211,8 @@ def generate_report(
         remove_ids=remove_ids,
         id_patterns=id_patterns,
         max_vif_iter=max_vif_iter,
+        n_steps=n_steps,
+        vif_n_steps=vif_n_steps,
         verbose=verbose,
     )
 

--- a/vassoura/tests/test_core.py
+++ b/vassoura/tests/test_core.py
@@ -76,3 +76,27 @@ def test_clean():
     # 'x2' deve ser removida (alta correlação com x1) mas x1 deve permanecer
     assert "x2" in dropped
     assert "x1" in df_clean.columns
+
+
+def test_clean_fractional_steps():
+    df = _make_dummy_df()
+    df1, dropped1, _, _ = vs.clean(
+        df,
+        target_col="target",
+        keep_cols=["x1"],
+        corr_threshold=0.9,
+        vif_threshold=5,
+        verbose=False,
+    )
+    df2, dropped2, _, _ = vs.clean(
+        df,
+        target_col="target",
+        keep_cols=["x1"],
+        corr_threshold=0.9,
+        vif_threshold=5,
+        n_steps=2,
+        vif_n_steps=2,
+        verbose=False,
+    )
+    assert df1.equals(df2)
+    assert set(dropped1) == set(dropped2)


### PR DESCRIPTION
## Summary
- add `n_steps` and `vif_n_steps` parameters to cleaning pipeline
- support stepwise variable dropping in correlation and VIF
- expose the new options in report generation
- test compatibility of fractional steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436d84799483218bd0f5f70559a93d