### PR TITLE
Fix IV history update

### DIFF
--- a/vassoura/core.py
+++ b/vassoura/core.py
@@ -375,6 +375,9 @@ class Vassoura:
         low_iv = self._iv_series[self._iv_series < thr].index.tolist()
         if low_iv:
             self._drop(low_iv, reason=f"iv<{thr}")
+        else:
+            # Log execução mesmo sem remoções para manter histórico consistente
+            self._history.append({"cols": [], "reason": f"iv<{thr}"})
 
     def _apply_importance(self) -> None:
         if self.target_col is None:


### PR DESCRIPTION
## Summary
- ensure `_apply_iv` records an empty history entry when no columns are dropped

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6843be1978508321b1130d2c0172f40f