### PR TITLE
Improve test coverage and fix panel date helper

### DIFF
--- a/vassoura/tests/test_autocorr.py
+++ b/vassoura/tests/test_autocorr.py
@@ -2,21 +2,24 @@ from __future__ import annotations
 
 import numpy as np
 import pandas as pd
+import pytest
 
-from vassoura.autocorrelacao import compute_panel_acf, plot_panel_acf
+from vassoura.autocorrelacao import compute_panel_acf, plot_panel_acf, _make_period_index
 from vassoura.analisador import analisar_autocorrelacao
 
 
 def _make_panel_df(n_contracts: int = 10, months: int = 18) -> pd.DataFrame:
+    """Dataset sintético de painel com datas válidas no formato YYYYMM."""
     rng = np.random.default_rng(0)
     rows = []
     for i in range(n_contracts):
-        start = 202001
+        start = pd.Period("2020-01", freq="M")
         for m in range(months):
+            period = start + m
             rows.append(
                 {
                     "cid": i,
-                    "ym": start + m,
+                    "ym": int(period.strftime("%Y%m")),
                     "val": rng.normal() + i * 0.1,
                 }
             )
@@ -63,4 +66,9 @@ def test_plot_panel_acf() -> None:
     )
     ax = plot_panel_acf(panel, title="test")
     assert ax.get_title() == "test"
+
+
+def test_make_period_index_invalid():
+    with pytest.raises(ValueError):
+        _make_period_index(pd.Series([202013]))
 

--- a/vassoura/tests/test_utils.py
+++ b/vassoura/tests/test_utils.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from vassoura.utils import suggest_corr_method, figsize_from_matrix, criar_dataset_pd_behavior
+
+def test_suggest_corr_method():
+    assert suggest_corr_method(["a", "b"], []) == "pearson"
+    assert suggest_corr_method(["a"], ["c"]) == "spearman"
+    assert suggest_corr_method([], ["c"]) == "cramer"
+
+def test_figsize_from_matrix_bounds():
+    small = figsize_from_matrix(2, base=0.4, min_size=6, max_size=20)
+    large = figsize_from_matrix(100, base=0.4, min_size=6, max_size=20)
+    assert small[0] >= 6 and small[0] == small[1]
+    assert large[0] <= 20 and large[0] == large[1]
+
+def test_criar_dataset_pd_behavior_columns():
+    df = criar_dataset_pd_behavior(n_clientes=5, max_anos=1, n_features=3, seed=0)
+    expected_cols = {"NroContrato", "AnoMesReferencia", "feature_01", "feature_02", "feature_03", "ever90m12"}
+    assert expected_cols <= set(df.columns)
+    # AnoMesReferencia deve estar no formato YYYYMM (int)
+    assert df["AnoMesReferencia"].dtype == int


### PR DESCRIPTION
## Summary
- fix `_make_panel_df` to produce valid YYYYMM months
- add regression test for invalid period index
- add utility tests for helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bf6d813483219f1d81f4a8194eb3