### PR TITLE
Fix date warnings and add logging demo

### DIFF
--- a/vassoura/examples/3_vassoura_pd_behavior_v2.ipynb
+++ b/vassoura/examples/3_vassoura_pd_behavior_v2.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "28346615",
+   "metadata": {},
+   "source": [
+    "# Exemplo PD Behavior v2\n",
+    "\n",
+    "Este notebook demonstra os novos recursos de logs configuráveis e tratamento de datas do pacote `vassoura`. O dataset é o mesmo gerado por `criar_dataset_pd_behavior`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd9b3dfc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import pandas as pd\n",
+    "import vassoura as vs\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO, format='%(levelname)s | %(message)s')\n",
+    "logger = logging.getLogger('vassoura')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3344984d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = vs.criar_dataset_pd_behavior(n_clientes=1000, max_anos=3, n_features=5, seed=0)\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad391cbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_cols, cat_cols = vs.search_dtypes(df, date_col=['AnoMesReferencia'], verbose='full')\n",
+    "print('Numéricas:', num_cols)\n",
+    "print('Categóricas:', cat_cols)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9a7b7c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_clean, dropped, corr_final, vif_final = vs.clean(\n",
+    "    df,\n",
+    "    target_col='ever90m12',\n",
+    "    date_col=['AnoMesReferencia'],\n",
+    "    verbose='basic'\n",
+    ")\n",
+    "print('Removidas:', dropped)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebaddd8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger.setLevel(logging.WARNING)\n",
+    "# Executar novamente sem logs detalhados\n",
+    "_ = vs.search_dtypes(df, date_col=['AnoMesReferencia'], verbose='full')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/vassoura/utils.py
+++ b/vassoura/utils.py
@@ -184,7 +184,13 @@ def search_dtypes(
         s = df_work[col]
         try:
             if col in date_col:
-                pd.to_datetime(s, errors="coerce")
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore",
+                        message="Could not infer format",
+                        category=UserWarning,
+                    )
+                    pd.to_datetime(s, errors="coerce", dayfirst=True)
                 if verbose_types:
                     LOGGER.info("%s -> datetime (explicit)", col)
                 continue
@@ -213,7 +219,13 @@ def search_dtypes(
                 continue
 
             # Colunas object / string
-            try_dt = pd.to_datetime(s, errors="coerce", dayfirst=True)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="Could not infer format",
+                    category=UserWarning,
+                )
+                try_dt = pd.to_datetime(s, errors="coerce", dayfirst=True)
             if try_dt.notna().mean() > 0.8 and try_dt.notna().any():
                 if verbose_types:
                     LOGGER.info("%s -> datetime (auto)", col)


### PR DESCRIPTION
## Summary
- suppress Pandas date inference warnings in `search_dtypes`
- add example notebook demonstrating configurable logging and date handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844497cfc3083219c533a545f484aaf