### PR TITLE
Improve logging around correlation fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ pyproject.toml             # Configuração do projeto
 * **Métodos**: `pearson`, `spearman`, `cramer`, ou `auto` (decide com base nos tipos).
 * Gera **DataFrame** de correlação e **heat‑map** Seaborn com dimensionamento automático (anotações opcionais).
 * Pode utilizar `engine="dask"` ou `engine="polars"` para grandes DataFrames.
+* Caso o método escolhido não seja suportado pelo engine, a função faz fallback
+  para pandas e registra esse fato no log.
 
 ### 3. VIF (`compute_vif`, `remove_high_vif`)
 

--- a/vassoura/correlacao.py
+++ b/vassoura/correlacao.py
@@ -159,6 +159,7 @@ def compute_corr_matrix(
         data = df_work[num_cols].copy()
         if adaptive_sampling:
             data = maybe_sample(data)
+        corr_engine = engine
         if engine == "dask":
             try:
                 import dask.dataframe as dd
@@ -168,6 +169,11 @@ def compute_corr_matrix(
             if method == "pearson":
                 corr = data_dd.corr(method="pearson").compute()
             else:
+                LOGGER.info(
+                    "Método %s não suportado por engine 'dask'; utilizando pandas.",
+                    method,
+                )
+                corr_engine = "pandas"
                 corr = data.corr(method=method)
         elif engine == "polars":
             try:
@@ -177,14 +183,20 @@ def compute_corr_matrix(
             if method == "pearson":
                 corr = pl.from_pandas(data).corr().to_pandas()
             else:
+                LOGGER.info(
+                    "Método %s não suportado por engine 'polars'; utilizando pandas.",
+                    method,
+                )
+                corr_engine = "pandas"
                 corr = data.corr(method=method)
         else:
             corr = data.corr(method=method)
         if verbose:
             LOGGER.info(
-                "Matriz de correlação %s calculada para %d " "variáveis numéricas",
+                "Matriz de correlação %s calculada para %d variáveis numéricas (engine=%s)",
                 method,
                 len(num_cols),
+                corr_engine,
             )
         return corr
 


### PR DESCRIPTION
## Summary
- clarify that compute_corr_matrix falls back to pandas when method isn't supported
- log fallback engine information
- mention fallback logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684456a5e970832194f13eb127ede27a