### PR TITLE
Add new heuristics and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Além disso:
 * **Dynamic Engine**: basta passar `engine="polars"` ou `"dask"` que o pipeline inteiro muda de engrenagem.
 * **Suporte total a IDs & Datas**: informe `id_cols` e `date_cols` na instância e elas ficarão protegidas do processo de limpeza e ordenação.
 
+### Heurísticas avançadas
+
+As seguintes heurísticas extras podem ser combinadas livremente no parâmetro `heuristics`:
+
+* `psi_stability` – calcula o Population Stability Index para duas janelas temporais.
+* `ks_separation` – remove variáveis com baixo poder de separação pelo KS-statistic.
+* `perm_importance` – ranking rápido via LightGBM e permutação.
+* `partial_corr_cluster` – clusterização por correlação parcial com corte mínimo em grafo.
+* `drift_leak` – identifica vazamentos de informação relacionados à data de referência.
+
 ---
 
 ## 📚 Documentação

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -17,3 +17,18 @@ which variables to drop.
 ### `variance(df, var_threshold=1e-4, dom_threshold=0.95, min_nonnull=30, keep_cols=None)`
 Drop features with very low numerical variance or with a single dominant
 category.
+
+### `psi_stability(df, date_col, window, target_col=None, bins=10, psi_thr=0.25, keep_cols=None)`
+Calculate the Population Stability Index comparing two time windows.
+
+### `ks_separation(df, target_col, ks_thr=0.05, n_bins=10, keep_cols=None)`
+Remove columns with KS-statistic below the threshold.
+
+### `perm_importance_lgbm(df, target_col, metric='auc', n_estimators=300, drop_lowest=0.2, random_state=42, keep_cols=None)`
+Drop the least important features according to LightGBM permutation importance.
+
+### `partial_corr_cluster(df, corr_thr=0.6, keep_cols=None, method='pearson')`
+Build a graph using partial correlations and remove a minimal vertex cover.
+
+### `drift_vs_target_leakage(df, date_col, target_col, drift_thr=0.3, leak_thr=0.5, keep_cols=None)`
+Detect features highly correlated with both the date column and the target (potential leakage).

--- a/vassoura/relatorio.py
+++ b/vassoura/relatorio.py
@@ -187,6 +187,11 @@ def generate_report(
         vif_before = precomputed.get("vif_before")
         corr_after = precomputed.get("corr_after")
         vif_after = precomputed.get("vif_after")
+        psi_series = precomputed.get("psi_series")
+        ks_series = precomputed.get("ks_series")
+        perm_series = precomputed.get("perm_series")
+        partial_graph = precomputed.get("partial_graph")
+        drift_leak_df = precomputed.get("drift_leak_df")
         id_cols = precomputed.get("id_cols", id_cols or [])
         date_cols = precomputed.get("date_cols", date_cols or [])
         ignore_cols = precomputed.get("ignore_cols", ignore_cols or [])
@@ -198,6 +203,11 @@ def generate_report(
         vif_before = None
         corr_after = None
         vif_after = None
+        psi_series = None
+        ks_series = None
+        perm_series = None
+        partial_graph = None
+        drift_leak_df = None
         id_cols = id_cols or []
         date_cols = date_cols or []
         ignore_cols = ignore_cols or []
@@ -461,11 +471,41 @@ img{{border:1px solid #e1e6eb;border-radius:var(--radius);}}
             html += "<p><i>Nenhuma variável removida; VIF estava dentro do limiar definido.</i></p>\n"
         html += "</div>\n"
 
+        if psi_series is not None:
+            html += "<div class=\"section\" id=\"psi\">"
+            html += "<h2>5. Estabilidade Temporal (PSI)</h2>"
+            html += psi_series.to_frame().to_html(classes="audit", float_format="{:.3f}".format)
+            html += "</div>\n"
+
+        if ks_series is not None:
+            html += "<div class=\"section\" id=\"ks\">"
+            html += "<h2>6. KS Separation</h2>"
+            html += ks_series.to_frame().to_html(classes="audit", float_format="{:.3f}".format)
+            html += "</div>\n"
+
+        if perm_series is not None:
+            html += "<div class=\"section\" id=\"perm\">"
+            html += "<h2>7. Permutation Importance</h2>"
+            html += perm_series.to_frame().to_html(classes="audit", float_format="{:.3f}".format)
+            html += "</div>\n"
+
+        if partial_graph is not None:
+            html += "<div class=\"section\" id=\"partial\">"
+            html += "<h2>8. Partial Correlation Cluster</h2>"
+            html += f"<p>{len(partial_graph.nodes())} variáveis no vertex cover.</p>"
+            html += "</div>\n"
+
+        if drift_leak_df is not None:
+            html += "<div class=\"section\" id=\"drift\">"
+            html += "<h2>9. Drift vs Target Leakage</h2>"
+            html += drift_leak_df.to_html(classes="audit", float_format="{:.3f}".format)
+            html += "</div>\n"
+
         # Seção de variáveis removidas
         html += textwrap.dedent(
             f"""
             <div class="section">
-                <h2>5. Variáveis Removidas</h2>
+                <h2>10. Variáveis Removidas</h2>
                 <ul>
             """
         )
@@ -524,7 +564,22 @@ img{{border:1px solid #e1e6eb;border-radius:var(--radius);}}
             ## 4. VIF Após a Limpeza
             {vif_after.to_markdown(index=False) if vif_after is not None else '*Nenhuma variável removida*'}
 
-            ## 5. Variáveis Removidas
+            ## 5. Estabilidade Temporal (PSI)
+            {psi_series.to_markdown() if psi_series is not None else '*não calculado*'}
+
+            ## 6. KS Separation
+            {ks_series.to_markdown() if ks_series is not None else '*não calculado*'}
+
+            ## 7. Permutation Importance
+            {perm_series.to_markdown() if perm_series is not None else '*não calculado*'}
+
+            ## 8. Partial Correlation Cluster
+            {len(partial_graph.nodes()) if partial_graph is not None else 0} variáveis no vertex cover
+
+            ## 9. Drift vs Target Leakage
+            {drift_leak_df.to_markdown() if drift_leak_df is not None else '*não calculado*'}
+
+            ## 10. Variáveis Removidas
             {', '.join(dropped_cols) or '*nenhuma*'}
             """
         )

--- a/vassoura/tests/test_advanced_heuristics.py
+++ b/vassoura/tests/test_advanced_heuristics.py
@@ -1,0 +1,59 @@
+import numpy as np
+import pandas as pd
+from vassoura.core import Vassoura
+from vassoura.heuristics import psi_stability, ks_separation
+
+
+def test_psi_stability_removal():
+    df = pd.DataFrame({
+        "date": ["2024-01"] * 50 + ["2025-01"] * 50,
+        "x": np.r_[np.random.normal(0, 1, 50), np.random.normal(3, 1, 50)],
+        "y": np.r_[np.random.normal(0, 1, 50), np.random.normal(0, 1, 50)],
+        "z": np.random.normal(size=100),
+        "target": np.random.randint(0, 2, 100),
+    })
+    result = psi_stability(df, date_col="date", window=("2024-01", "2025-01"), psi_thr=0.25)
+    assert "x" in result["removed"]
+
+
+def test_ks_separation():
+    rng = np.random.default_rng(1)
+    target = rng.integers(0, 2, 1000)
+    weak = rng.normal(size=1000)
+    strong = target + rng.normal(scale=0.1, size=1000)
+    df = pd.DataFrame({"target": target, "weak": weak, "strong": strong})
+    result = ks_separation(df, target_col="target", ks_thr=0.05)
+    assert "weak" in result["removed"] and "strong" not in result["removed"]
+
+
+def test_perm_importance_keep_cols():
+    rng = np.random.default_rng(2)
+    df = pd.DataFrame(rng.normal(size=(100, 5)), columns=list("abcde"))
+    df["target"] = (df["a"] + rng.normal(size=100)) > 0
+    vs = Vassoura(df, target_col="target", heuristics=["perm_importance"], keep_cols=["e"], thresholds={"perm_importance": 0.4})
+    out = vs.run()
+    assert "e" in out.columns
+    assert out.shape[1] <= 6
+
+
+def test_partial_corr_cluster():
+    rng = np.random.default_rng(3)
+    x1 = rng.normal(size=150)
+    x2 = x1 * 0.9 + rng.normal(scale=0.1, size=150)
+    x3 = rng.normal(size=150)
+    df = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+    vs = Vassoura(df, heuristics=["partial_corr_cluster"], thresholds={"partial_corr_cluster": 0.6})
+    out = vs.run()
+    assert ("x1" not in out.columns) or ("x2" not in out.columns)
+
+
+def test_drift_vs_target_leakage():
+    rng = np.random.default_rng(4)
+    dates = pd.date_range("2024-01-01", periods=100, freq="D")
+    target = rng.integers(0, 2, 100)
+    leak = np.arange(100) + target * 80
+    safe = rng.normal(size=100)
+    df = pd.DataFrame({"date": dates, "leak": leak, "safe": safe, "target": target})
+    vs = Vassoura(df, target_col="target", date_cols=["date"], heuristics=["drift_leak"], thresholds={"drift_leak_drift": 0.4, "drift_leak_leak": 0.5})
+    out = vs.run()
+    assert "leak" not in out.columns and "safe" in out.columns


### PR DESCRIPTION
## Summary
- implement psi_stability, ks_separation, perm_importance_lgbm, partial_corr_cluster and drift_vs_target_leakage
- integrate new heuristics in Vassoura core and reporting
- document advanced heuristics in README and docs
- provide unit tests for new heuristics

## Testing
- `pip install pandas numpy scipy seaborn matplotlib statsmodels pytest`
- `pip install networkx`
- `pip install lightgbm==4.3.0`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684475e1eaac8321beac9af6001b17e2