### PR TITLE
Modern report with flare palette

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ statsmodels>=0.14
 polars>=1.30.0
 dask>=2025.5.1
 mplcursors==0.6
+shap>=0.47
+lightgbm>=4.0

--- a/vassoura/heuristics.py
+++ b/vassoura/heuristics.py
@@ -420,8 +420,11 @@ def perm_importance_lgbm(
         )
     model.fit(X, y)
 
+    score = metric
+    if metric == "auc":
+        score = "roc_auc"
     result = permutation_importance(
-        model, X, y, scoring=metric, random_state=random_state, n_repeats=5
+        model, X, y, scoring=score, random_state=random_state, n_repeats=5
     )
     imp = pd.Series(result.importances_mean, index=X.columns, name="perm_imp")
 

--- a/vassoura/tests/test_relatorio_modern.py
+++ b/vassoura/tests/test_relatorio_modern.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from unittest.mock import patch
+
+import vassoura as vs
+
+
+def _make_df(n=120):
+    rng = np.random.default_rng(0)
+    x1 = rng.normal(size=n)
+    x2 = x1 * 0.9 + rng.normal(scale=0.1, size=n)
+    x3 = rng.normal(size=n)
+    target = (x1 + x3 + rng.normal(size=n)) > 0
+    data = {"x1": x1, "x2": x2, "x3": x3, "target": target.astype(int)}
+    for i in range(60):
+        data[f"f{i}"] = rng.normal(size=n)
+    return pd.DataFrame(data)
+
+
+def test_generate_report_modern(tmp_path):
+    df = _make_df()
+    sess = vs.Vassoura(df, target_col="target", heuristics=["corr", "vif"], verbose="none")
+    sess.run(recompute=True)
+    with patch("lightgbm.LGBMClassifier") as MockLGBM, patch(
+        "shap.TreeExplainer"
+    ) as MockExpl:
+        MockLGBM.return_value.fit.return_value = MockLGBM.return_value
+        MockExpl.return_value.shap_values.return_value = [np.zeros((len(df), 63)), np.zeros((len(df), 63))]
+        path = Path(sess.generate_report(path=tmp_path / "r.html"))
+        assert MockLGBM.call_args[1]["class_weight"] == "balanced"
+    html = path.read_text()
+    import re
+
+    m = re.search(r'<div class="vif-grid"><img src="data:image/[^;]+;base64,([^" ]+)', html)
+    assert m and len(m.group(1)) > 100000
+    assert html.count("<div class=\"vif-grid\">") == 1
+    assert "KS Separation" not in html
+    assert "flare_" in html
+    assert "shadow" in sess.df_current.columns


### PR DESCRIPTION
## Summary
- use flare palette heatmaps with legible text
- show VIF before/after side-by-side
- drop KS separation section
- add shadow-feature analysis section
- update requirements and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844802180088321a63232c6771a484b