### PR TITLE
Fix test requiring networkx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "matplotlib>=3.8",
     "scipy>=1.11",
     "statsmodels>=0.14",
+    "networkx>=3.2",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ dask>=2025.5.1
 mplcursors==0.6
 shap>=0.47
 lightgbm>=4.0
+networkx>=3.2


### PR DESCRIPTION
## Summary
- add missing networkx dependency in project configuration
- include the dependency in requirements.txt

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448678e65c8321b763693c0e4bea95