### PR TITLE
Revamp shadow feature charts and report

### DIFF
--- a/vassoura/tests/test_relatorio_modern.py
+++ b/vassoura/tests/test_relatorio_modern.py
@@ -37,4 +37,4 @@ def test_generate_report_modern(tmp_path):
     assert html.count("<div class=\"vif-grid\">") == 1
     assert "KS Separation" not in html
     assert "flare_" in html
-    assert "shadow" in sess.df_current.columns
+    assert "__shadow__" in sess.df_current.columns


### PR DESCRIPTION
## Summary
- silence LightGBM warnings inside `generate_report`
- compute KS and SHAP gain side by side with `__shadow__` feature
- embed combined image in HTML report
- update docs and tests for new `__shadow__` naming

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a149583883219b56040c1db6e7bb