### PR TITLE
Improve audit trail & VIF plots

### DIFF
--- a/vassoura/tests/test_relatorio_modern.py
+++ b/vassoura/tests/test_relatorio_modern.py
@@ -38,10 +38,13 @@ def test_generate_report_modern(tmp_path):
     html = path.read_text()
     import re
 
-    m = re.search(
-        r'<div class="vif-grid"><img src="data:image/[^;]+;base64,([^" ]+)', html
+    section = re.search(
+        r'<div class="vif-grid">(.*?)</div>', html, flags=re.S
     )
-    assert m and len(m.group(1)) > 20000
+    assert section
+    imgs = re.findall(r'<img src="data:image/[^;]+;base64,([^" ]+)', section.group(1))
+    assert len(imgs) == 2
+    assert all(len(i) > 10000 for i in imgs)
     assert html.count('<div class="vif-grid">') == 1
     assert "KS Separation" not in html
     assert "flare_" in html


### PR DESCRIPTION
## Summary
- store metric values for each drop in history
- display two separate VIF charts
- aggregate audit trail rows by heuristic with tooltips
- suppress warnings and handle HTML encoding
- update tests for new VIF section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c78056688321ba8cd8f038137810