### PR TITLE
Fix importance with WOE encoding and date exclusion

### DIFF
--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -8,6 +8,7 @@ Remove features with Information Value below the threshold.
 
 ### `importance(df, target_col, n_estimators=100, learning_rate=0.1, subsample=0.8, keep_cols=None, drop_lowest=0.2, random_state=42)`
 Train a light XGBoost model and drop the lowest scoring features using SHAP gain.
+Categorical columns are automatically encoded via a lightweight WOE scheme.
 Requires `xgboost` and `shap` installed.
 
 ### `graph_cut(df, corr_threshold=0.9, keep_cols=None, method='pearson')`

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -16,3 +16,7 @@ Compute a square `figsize` adequate for correlation heatmaps.
 ### `criar_dataset_pd_behavior(n_clientes=1000, max_anos=5, n_features=20, seed=42)`
 Generate a synthetic behavioural credit dataset useful for examples and
 unit tests.
+
+### `woe_encode(df, target, cols=None, smoothing=0.5)`
+Return a copy of `df` with selected categorical columns replaced by Weight of
+Evidence values. Only binary targets are supported.

--- a/vassoura/core.py
+++ b/vassoura/core.py
@@ -673,8 +673,9 @@ class Vassoura:
 
         from .heuristics import importance
 
+        df_work = self._df_for_analysis()
         result = importance(
-            self.df_current,
+            df_work,
             target_col=self.target_col,
             keep_cols=list(self.keep_cols),
             params=params,

--- a/vassoura/heuristics.py
+++ b/vassoura/heuristics.py
@@ -211,9 +211,11 @@ def importance(
 
         X["__shadow__"] = rng.random(len(X))
 
-        # simple encoding for categoricals
-        for col in X.select_dtypes(include=["object", "category"]).columns:
-            X[col] = pd.Categorical(X[col]).codes
+        # WOE encoding for categoricals
+        cat_cols = X.select_dtypes(include=["object", "category"]).columns.tolist()
+        if cat_cols:
+            from .utils import woe_encode
+            X = woe_encode(X, y, cols=cat_cols)
         X = X.fillna(0)
 
         fit_params = {}


### PR DESCRIPTION
## Summary
- exclude date columns when running importance heuristic
- encode categorical columns using a lightweight WOE encoder
- document the new function and behaviour

## Testing
- `python -m pip install -q -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684513413e308321a8419bd4dfac9ada