### PR TITLE
Add scalable process and tests

### DIFF
--- a/vassoura/tests/test_core.py
+++ b/vassoura/tests/test_core.py
@@ -154,6 +154,7 @@ def test_iv_skipped_when_target_not_binary(capsys):
     vsess = vs.Vassoura(
         df,
         target_col="id",
+        process=[],
         heuristics=["iv"],
         verbose=True,
     )

--- a/vassoura/tests/test_scaler.py
+++ b/vassoura/tests/test_scaler.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pandas as pd
+from sklearn.preprocessing import StandardScaler
+
+from vassoura.scaler import DynamicScaler
+
+
+def test_roundtrip_auto():
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame({
+        "a": rng.normal(size=100),
+        "b": rng.lognormal(size=100),
+    })
+    sc = DynamicScaler()
+    sc.fit(df)
+    tr = sc.transform(df, return_df=True)
+    inv = sc.inverse_transform(tr, return_df=True)
+    assert np.allclose(df.values, inv.values, atol=1e-6, rtol=1e-6)
+
+
+def test_standard_strategy():
+    df = pd.DataFrame({"x": np.random.normal(size=50), "y": np.random.normal(size=50)})
+    sc = DynamicScaler(strategy="standard")
+    sc.fit(df)
+    assert all(isinstance(s, StandardScaler) for s in sc.scalers_.values())
+
+
+def test_save_load(tmp_path):
+    df = pd.DataFrame({"x": np.random.normal(size=30), "y": np.random.normal(size=30)})
+    sc = DynamicScaler()
+    sc.fit(df)
+    p = tmp_path / "scaler.pkl"
+    sc.save(p)
+    sc2 = DynamicScaler().load(p)
+    assert np.allclose(sc.transform(df), sc2.transform(df))

--- a/vassoura/tests/test_variance.py
+++ b/vassoura/tests/test_variance.py
@@ -5,7 +5,7 @@ from vassoura.core import Vassoura
 
 def test_variance_removes_constant():
     df = pd.DataFrame({"const": 1, "x": np.random.normal(size=100)})
-    vs = Vassoura(df, heuristics=["variance"], params={"variance": 1e-4})
+    vs = Vassoura(df, process=["variance"], heuristics=[], params={"variance": 1e-4})
     out = vs.run()
     assert "const" not in out.columns
     assert any("variance" in h["reason"] for h in vs.history)
@@ -13,7 +13,7 @@ def test_variance_removes_constant():
 
 def test_variance_keeps_variable():
     df = pd.DataFrame({"x": np.random.normal(size=100)})
-    vs = Vassoura(df, heuristics=["variance"], params={"variance": 1e-4})
+    vs = Vassoura(df, process=["variance"], heuristics=[], params={"variance": 1e-4})
     out = vs.run()
     assert "x" in out.columns
 
@@ -23,7 +23,8 @@ def test_dominant_category_removed():
     df = pd.DataFrame({"cat": cat, "x": np.random.normal(size=100)})
     vs = Vassoura(
         df,
-        heuristics=["variance"],
+        process=["variance"],
+        heuristics=[],
         params={"variance": 1e-4, "variance_dom": 0.95},
     )
     out = vs.run()
@@ -34,7 +35,8 @@ def test_keep_cols_protected():
     df = pd.DataFrame({"const": 1, "x": np.random.normal(size=50)})
     vs = Vassoura(
         df,
-        heuristics=["variance"],
+        process=["variance"],
+        heuristics=[],
         params={"variance": 1e-4},
         keep_cols=["const"],
     )


### PR DESCRIPTION
## Summary
- support separation of `process` and `heuristics`
- add DynamicScaler process
- keep output unscaled with reverse transform
- ensure DynamicScaler is cloneable
- add unit tests for the scaler
- update variance tests to use new process parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452491b1b48321bfd7785c2cac1af2