### PR TITLE
Implement DynamicScaler fixes and enforce scaler ordering

### DIFF
--- a/vassoura/tests/test_core.py
+++ b/vassoura/tests/test_core.py
@@ -154,7 +154,7 @@ def test_iv_skipped_when_target_not_binary(capsys):
     vsess = vs.Vassoura(
         df,
         target_col="id",
-        process=[],
+        process=["scaler"],
         heuristics=["iv"],
         verbose=True,
     )


### PR DESCRIPTION
## Summary
- ensure DynamicScaler detects pre-scaled columns and refuses transform before fit
- add verbose logging hooks and optional log level
- preserve scaled data for heuristics and return original values
- enforce that scaler runs before heuristics in `Vassoura.run`
- update IV test for new scaler requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a88590e08321abf09d359e466b7c