### PR TITLE
Centralize logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ pip install -e .[dev]
 
 Caso esses pacotes não estejam disponíveis, o Vassoura faz *fallback* elegante para `pandas`.
 
+Para configurar os logs de todo o pacote basta executar::
+
+    import vassoura
+    vassoura.configure_logging()
+
 ---
 
 ## ✨ Principais Funcionalidades
@@ -76,6 +81,7 @@ A documentação detalhada (API, tutoriais, FAQ) mora na pasta [`docs/`](docs) e
 
 ```python
 import pandas as pd
+
 from vassoura import Vassoura
 
 # dataset fictício

--- a/vassoura/__init__.py
+++ b/vassoura/__init__.py
@@ -1,20 +1,20 @@
 __version__ = "0.1.0"
 
+from . import _compat  # importa ajustes de compatibilidade (não está no __all__)
+from .analisador import analisar_autocorrelacao
+from .autocorrelacao import compute_panel_acf, plot_panel_acf
+from .core import Vassoura
+from .correlacao import compute_corr_matrix, plot_corr_heatmap
+from .limpeza import clean
+from .logging_utils import configure_logging
+from .relatorio import generate_report
 from .utils import (
+    criar_dataset_pd_behavior,
+    figsize_from_matrix,
     search_dtypes,
     suggest_corr_method,
-    figsize_from_matrix,
-    criar_dataset_pd_behavior,
 )
-
-from . import _compat  # importa ajustes de compatibilidade (não está no __all__)
-from .correlacao import compute_corr_matrix, plot_corr_heatmap
 from .vif import compute_vif, remove_high_vif
-from .limpeza import clean
-from .relatorio import generate_report
-from .autocorrelacao import compute_panel_acf, plot_panel_acf
-from .analisador import analisar_autocorrelacao
-from .core import Vassoura
 
 __all__ = [
     "search_dtypes",
@@ -30,5 +30,6 @@ __all__ = [
     "compute_panel_acf",
     "plot_panel_acf",
     "analisar_autocorrelacao",
-    "Vassoura"
+    "Vassoura",
+    "configure_logging",
 ]

--- a/vassoura/autocorrelacao.py
+++ b/vassoura/autocorrelacao.py
@@ -18,13 +18,13 @@ Funções públicas
 import logging
 from typing import Dict, List, Literal, Tuple
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
 from statsmodels.tsa.stattools import acf
-import matplotlib.pyplot as plt
 
-LOGGER = logging.getLogger("vassoura")
+LOGGER = logging.getLogger(__name__)
 
 __all__ = ["compute_panel_acf", "plot_panel_acf"]
 

--- a/vassoura/core.py
+++ b/vassoura/core.py
@@ -20,12 +20,12 @@ import pandas as pd
 
 from .correlacao import compute_corr_matrix
 from .heuristics import (
-    graph_cut,
-    psi_stability,
-    ks_separation,
-    perm_importance_lgbm,
-    partial_corr_cluster,
     drift_vs_target_leakage,
+    graph_cut,
+    ks_separation,
+    partial_corr_cluster,
+    perm_importance_lgbm,
+    psi_stability,
 )
 from .relatorio import generate_report
 from .utils import parse_verbose
@@ -72,12 +72,7 @@ from .vif import compute_vif
 #     return iv
 
 # Logger padrão (o usuário pode sobrescrever o handler/formato fora da lib)
-logger = logging.getLogger("vassoura.iv")
-if not logger.handlers:  # evita handlers duplicados em notebooks
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
-    logger.addHandler(handler)
-logger.setLevel(logging.WARNING)  # default → não imprime nada “extra”
+logger = logging.getLogger(__name__)
 
 
 def _compute_iv(
@@ -266,7 +261,9 @@ class Vassoura:
         self.vif_n_steps = vif_n_steps
 
         self.process = process if process is not None else DEFAULT_PROCESS.copy()
-        self.heuristics = DEFAULT_HEURISTICS.copy() if heuristics is None else heuristics
+        self.heuristics = (
+            DEFAULT_HEURISTICS.copy() if heuristics is None else heuristics
+        )
         # Valores padrão, podem ser sobrescritos
         self.params = {
             "corr": 0.9,
@@ -276,7 +273,6 @@ class Vassoura:
             "variance_dom": 0.95,
             "psi_stability": 0.25,
             "ks_separation": 0.05,
-
             # ainda em testes
             "perm_importance": 0.2,
             "partial_corr_cluster": 0.6,
@@ -298,7 +294,7 @@ class Vassoura:
         self._variance_series: Optional[pd.Series] = None
         self._psi_series: Optional[pd.Series] = None
         self._ks_series: Optional[pd.Series] = None
-        
+
         self._perm_series: Optional[pd.Series] = None
         self._partial_graph: Any = None
         self._drift_leak_df: Optional[pd.DataFrame] = None
@@ -751,6 +747,7 @@ class Vassoura:
         if self.verbose:
             print("[Vassoura] Scaler process")
         from .scaler import DynamicScaler
+
         df_work = self._df_for_analysis()
         num_cols = df_work.select_dtypes(include=[np.number]).columns.tolist()
         if self.target_col in num_cols:
@@ -767,7 +764,9 @@ class Vassoura:
         self._df_scaled = self.df_current.copy()
 
     def _reverse_scaler(self) -> None:
-        cols = [c for c in getattr(self, "_scaled_cols", []) if c in self.df_current.columns]
+        cols = [
+            c for c in getattr(self, "_scaled_cols", []) if c in self.df_current.columns
+        ]
         if not cols or not hasattr(self, "_scaler"):
             return
         inv_df = self.df_current.copy()

--- a/vassoura/correlacao.py
+++ b/vassoura/correlacao.py
@@ -55,7 +55,7 @@ __all__ = [
     "plot_corr_heatmap",
 ]
 
-LOGGER = logging.getLogger("vassoura")
+LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Helpers internos

--- a/vassoura/limpeza.py
+++ b/vassoura/limpeza.py
@@ -22,14 +22,14 @@ import numpy as np
 import pandas as pd
 
 from .correlacao import compute_corr_matrix
-from .vif import compute_vif, remove_high_vif
 from .utils import parse_verbose
+from .vif import compute_vif, remove_high_vif
 
 __all__ = [
     "clean",
 ]
 
-LOGGER = logging.getLogger("vassoura")
+LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Funções auxiliares

--- a/vassoura/logging_utils.py
+++ b/vassoura/logging_utils.py
@@ -1,0 +1,35 @@
+import logging
+from typing import Optional
+
+
+def configure_logging(
+    level: int = logging.INFO, *, filename: Optional[str] = None
+) -> logging.Logger:
+    """Configure root ``vassoura`` logger with optional file output.
+
+    Parameters
+    ----------
+    level : int, optional
+        Logging level applied to the root logger, by default ``logging.INFO``.
+    filename : str | None, optional
+        If provided, logs are also written to this file. Otherwise
+        :class:`logging.StreamHandler` is used.
+
+    Returns
+    -------
+    logging.Logger
+        The configured ``vassoura`` logger.
+    """
+    logger = logging.getLogger("vassoura")
+
+    if filename:
+        handler: logging.Handler = logging.FileHandler(filename)
+    else:
+        handler = logging.StreamHandler()
+
+    handler.setFormatter(logging.Formatter("%(levelname)s | %(message)s"))
+
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    return logger

--- a/vassoura/relatorio.py
+++ b/vassoura/relatorio.py
@@ -40,7 +40,7 @@ from .vif import compute_vif
 
 __all__ = ["generate_report"]
 
-LOGGER = logging.getLogger("vassoura")
+LOGGER = logging.getLogger(__name__)
 
 
 def _fig_to_base64(fig: plt.Figure, *, fmt: str = "png") -> str:
@@ -415,16 +415,12 @@ def generate_report(
     n_before = len(series_before)
     n_after = len(series_after)
 
-    fig_vif_b, ax_b = plt.subplots(
-        figsize=(6, 0.25 * n_before + 1)
-    )
+    fig_vif_b, ax_b = plt.subplots(figsize=(6, 0.25 * n_before + 1))
     _plot_vif_barplot(series_before, "VIF antes da limpeza", ax_b, thr=vif_threshold)
     fig_vif_b.tight_layout()
     img_vif_before = _fig_to_base64(fig_vif_b)
 
-    fig_vif_a, ax_a = plt.subplots(
-        figsize=(6, 0.25 * n_after + 1)
-    )
+    fig_vif_a, ax_a = plt.subplots(figsize=(6, 0.25 * n_after + 1))
     _plot_vif_barplot(series_after, "VIF após a limpeza", ax_a, thr=vif_threshold)
     fig_vif_a.tight_layout()
     img_vif_after = _fig_to_base64(fig_vif_a)
@@ -733,7 +729,10 @@ img{{border:1px solid #e1e6eb;border-radius:var(--radius);}}
                         g["items"].append((c, v))
                 for g in groups.values():
                     g["items"].sort(
-                        key=lambda x: (x[1] is not None, x[1] if x[1] is not None else -np.inf),
+                        key=lambda x: (
+                            x[1] is not None,
+                            x[1] if x[1] is not None else -np.inf,
+                        ),
                         reverse=True,
                     )
                 return groups
@@ -745,7 +744,9 @@ img{{border:1px solid #e1e6eb;border-radius:var(--radius);}}
             html += '<table class="audit"><thead><tr><th>Heurística</th><th>Motivo</th><th>Colunas</th></tr></thead><tbody>'
             for heur, info in groups.items():
                 mot = info.get("mot", "")
-                html += f"<tr><td>{heur}</td><td>{mot}</td><td><div class='feature-grid'>"
+                html += (
+                    f"<tr><td>{heur}</td><td>{mot}</td><td><div class='feature-grid'>"
+                )
                 for col, val in info["items"]:
                     tipo = (
                         "num"

--- a/vassoura/scaler.py
+++ b/vassoura/scaler.py
@@ -1,29 +1,26 @@
 # -*- coding: utf-8 -*-
 import logging
-import time
 import pathlib
+import time
+import warnings
+
 import joblib
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 import seaborn as sns
 from scipy import stats
-from scipy.stats import shapiro, skew, kurtosis
-
+from scipy.stats import kurtosis, shapiro, skew
 from sklearn.base import BaseEstimator, TransformerMixin
-import warnings
 from sklearn.preprocessing import (
-    StandardScaler,
-    RobustScaler,
     MinMaxScaler,
     QuantileTransformer,
+    RobustScaler,
+    StandardScaler,
 )
 
-logger = logging.getLogger("vassoura.scaler")
-if not logger.handlers:
-    handler = logging.StreamHandler()
-    logger.addHandler(handler)
-logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 class DynamicScaler(BaseEstimator, TransformerMixin):
     """
@@ -57,17 +54,19 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
     # ------------------------------------------------------------------
     # INIT
     # ------------------------------------------------------------------
-    def __init__(self,
-                 strategy: str = 'auto',
-                 shapiro_p_val: float = 0.01,
-                 serialize: bool = False,
-                 save_path: str | pathlib.Path | None = None,
-                 random_state: int = 0,
-                 *,
-                 verbose: str = 'none',
-                 log_level: int | None = None,
-                 logger: logging.Logger | None = None,
-                 enable_scaler: bool = True):
+    def __init__(
+        self,
+        strategy: str = "auto",
+        shapiro_p_val: float = 0.01,
+        serialize: bool = False,
+        save_path: str | pathlib.Path | None = None,
+        random_state: int = 0,
+        *,
+        verbose: str = "none",
+        log_level: int | None = None,
+        logger: logging.Logger | None = None,
+        enable_scaler: bool = True,
+    ):
         # store raw parameter for scikit-learn compatibility
         self.strategy = strategy
         self.serialize = serialize
@@ -77,17 +76,14 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
         self.verbose = verbose
         self.enable_scaler = enable_scaler
         self.log_level = log_level
-        self.logger = logger or globals()["logger"]
+        self.logger = logger or logging.getLogger(__name__)
         if log_level is not None:
             self.logger.setLevel(log_level)
 
         self._save_path = pathlib.Path(save_path or "scalers.pkl")
-        if not self.logger.handlers:
-            handler = logging.StreamHandler()
-            self.logger.addHandler(handler)
 
         self.scalers_: dict[str, BaseEstimator] = {}
-        self.report_:  dict[str, dict] = {}      # estatísticas por coluna
+        self.report_: dict[str, dict] = {}  # estatísticas por coluna
         self.fitted_ = False
         self._fitted = False
 
@@ -107,53 +103,64 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
 
         # Coluna constante
         if sample.nunique() == 1:
-            return None, dict(reason='constante', scaler='None')
+            return None, dict(reason="constante", scaler="None")
 
         # ---------------- métricas básicas ----------------
         try:
-            p_val = shapiro(sample.sample(min(5000, len(sample)),
-                                          random_state=self.random_state))[1]
-        except Exception:   # amostra minúscula ou erro numérico
+            p_val = shapiro(
+                sample.sample(min(5000, len(sample)), random_state=self.random_state)
+            )[1]
+        except Exception:  # amostra minúscula ou erro numérico
             p_val = 0.0
 
         sk = skew(sample, nan_policy="omit")
-        kt = kurtosis(sample, nan_policy="omit")        # Fisher (0 = normal)
+        kt = kurtosis(sample, nan_policy="omit")  # Fisher (0 = normal)
 
         # ---------------- critérios de NÃO escalonar ----------------
         # (1) variável já em [0,1]
         if sample.min() >= 0 and sample.max() <= 1:
-            return None, dict(reason='pre-scaled [0-1]', scaler='None')
+            return None, dict(reason="pre-scaled [0-1]", scaler="None")
 
         # # (2) praticamente normal
         # if abs(sk) < 0.05 and abs(kt) < 0.1 and p_val > 0.90:
         #     return None, dict(p_value=p_val, skew=sk, kurtosis=kt,
         #                       reason='praticamente normal', scaler='None')
-        
+
         # (3) praticamente normal (menos restritivo)
         if abs(sk) < 0.5 and abs(kt) < 1.0 and p_val > self.shapiro_p_val:
             scaler = StandardScaler()
-            stats = dict(p_value=p_val, skew=sk, kurtosis=kt,
-                         reason='aproximadamente normal', scaler='StandardScaler')
+            stats = dict(
+                p_value=p_val,
+                skew=sk,
+                kurtosis=kt,
+                reason="aproximadamente normal",
+                scaler="StandardScaler",
+            )
             return scaler, stats
-
 
         # ---------------- escolha de scaler ----------------
         if p_val >= 0.05 and abs(sk) <= 0.5:
             scaler = StandardScaler()
-            reason = '≈normal'
+            reason = "≈normal"
         elif abs(sk) > 3 or kt > 20:
-            scaler = QuantileTransformer(output_distribution='normal',
-                                          random_state=self.random_state)
-            reason = 'assimetria/kurtosis extrema'
+            scaler = QuantileTransformer(
+                output_distribution="normal", random_state=self.random_state
+            )
+            reason = "assimetria/kurtosis extrema"
         elif abs(sk) > 0.5:
             scaler = RobustScaler()
-            reason = 'skew moderado/outliers'
+            reason = "skew moderado/outliers"
         else:
             scaler = MinMaxScaler()
-            reason = 'default'
+            reason = "default"
 
-        stats = dict(p_value=p_val, skew=sk, kurtosis=kt,
-                     reason=reason, scaler=scaler.__class__.__name__)
+        stats = dict(
+            p_value=p_val,
+            skew=sk,
+            kurtosis=kt,
+            reason=reason,
+            scaler=scaler.__class__.__name__,
+        )
         return scaler, stats
 
     # ------------------------------------------------------------------
@@ -168,55 +175,57 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
             self.logger.info("[DynamicScaler] start")
         strategy = self.strategy.lower() if self.strategy else None
 
-        if strategy not in {'auto', 'standard', 'robust',
-                            'minmax', 'quantile', None}:
+        if strategy not in {"auto", "standard", "robust", "minmax", "quantile", None}:
             raise ValueError(f"strategy '{self.strategy}' não suportada.")
 
         for col in X_df.columns:
             # --- seleção do scaler -----------------------------------
             if not self.enable_scaler:
                 scaler = None
-                stats = dict(reason='disabled', scaler='None')
-            elif strategy == 'auto':
+                stats = dict(reason="disabled", scaler="None")
+            elif strategy == "auto":
                 scaler, stats = self._choose_auto(X_df[col])
-            elif strategy == 'standard':
+            elif strategy == "standard":
                 scaler = StandardScaler()
-                stats  = dict(reason='global-standard', scaler='StandardScaler')
-            elif strategy == 'robust':
+                stats = dict(reason="global-standard", scaler="StandardScaler")
+            elif strategy == "robust":
                 scaler = RobustScaler()
-                stats  = dict(reason='global-robust', scaler='RobustScaler')
-            elif strategy == 'minmax':
+                stats = dict(reason="global-robust", scaler="RobustScaler")
+            elif strategy == "minmax":
                 scaler = MinMaxScaler()
-                stats  = dict(reason='global-minmax', scaler='MinMaxScaler')
-            elif strategy == 'quantile':
+                stats = dict(reason="global-minmax", scaler="MinMaxScaler")
+            elif strategy == "quantile":
                 if len(X_df) < 1000:
                     n_quantiles = min(1000, len(X_df))
-                    scaler = QuantileTransformer(n_quantiles=n_quantiles, output_distribution="uniform")
+                    scaler = QuantileTransformer(
+                        n_quantiles=n_quantiles, output_distribution="uniform"
+                    )
                 else:
-                    scaler = QuantileTransformer(output_distribution='normal',
-                                                random_state=self.random_state)
-                stats  = dict(reason='global-quantile', scaler='QuantileTransformer')
-            else:              # None
+                    scaler = QuantileTransformer(
+                        output_distribution="normal", random_state=self.random_state
+                    )
+                stats = dict(reason="global-quantile", scaler="QuantileTransformer")
+            else:  # None
                 scaler = None
-                stats  = dict(reason='passthrough', scaler='None')
+                stats = dict(reason="passthrough", scaler="None")
 
             # --- ajuste ---------------------------------------------
             if scaler is not None:
                 scaler.fit(X_df[[col]])
 
             self.scalers_[col] = scaler
-            self.report_[col]  = stats
+            self.report_[col] = stats
 
             # --- log -------------------------------------------------
             if self.verbose == "debug":
                 self.logger.debug(
                     "[DynamicScaler] %s -> %s (p=%.3f, skew=%.2f, kurt=%.1f) %s",
                     col,
-                    stats.get('scaler'),
-                    stats.get('p_value', np.nan),
-                    stats.get('skew', np.nan),
-                    stats.get('kurtosis', np.nan),
-                    stats['reason']
+                    stats.get("scaler"),
+                    stats.get("p_value", np.nan),
+                    stats.get("skew", np.nan),
+                    stats.get("kurtosis", np.nan),
+                    stats["reason"],
                 )
 
         # serialização opcional
@@ -286,9 +295,14 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
 
     def report_as_df(self) -> pd.DataFrame:
         """Devolve o relatório de métricas/decisões como DataFrame."""
-        return pd.DataFrame.from_dict(self.report_, orient='index')
+        return pd.DataFrame.from_dict(self.report_, orient="index")
 
-    def plot_histograms(self, original_df: pd.DataFrame, transformed_df: pd.DataFrame, features: str | list[str]):
+    def plot_histograms(
+        self,
+        original_df: pd.DataFrame,
+        transformed_df: pd.DataFrame,
+        features: str | list[str],
+    ):
         """
         Plota histogramas lado a lado (antes/depois do escalonamento) para uma ou mais variáveis.
 
@@ -321,19 +335,22 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
 
             # Original
             plt.subplot(1, 2, 1)
-            sns.histplot(original_df[feature].dropna(), bins=30, kde=True, color="steelblue")
+            sns.histplot(
+                original_df[feature].dropna(), bins=30, kde=True, color="steelblue"
+            )
             plt.title(f"{feature} — original")
             plt.xlabel(feature)
 
             # Transformada
             plt.subplot(1, 2, 2)
-            sns.histplot(transformed_df[feature].dropna(), bins=30, kde=True, color="darkorange")
+            sns.histplot(
+                transformed_df[feature].dropna(), bins=30, kde=True, color="darkorange"
+            )
             plt.title(f"{feature} — escalado com {scaler_nome}")
             plt.xlabel(feature)
 
             plt.tight_layout()
             plt.show()
-
 
     # ------------------------------------------------------------------
     # SERIALIZAÇÃO
@@ -341,21 +358,24 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
     def save(self, path: str | pathlib.Path | None = None):
         """Serializa scalers + relatório + metadados."""
         path = pathlib.Path(path or self._save_path)
-        joblib.dump({
-            'scalers': self.scalers_,
-            'report':  self.report_,
-            'strategy': self.strategy,
-            'random_state': self.random_state
-        }, path)
+        joblib.dump(
+            {
+                "scalers": self.scalers_,
+                "report": self.report_,
+                "strategy": self.strategy,
+                "random_state": self.random_state,
+            },
+            path,
+        )
         self.logger.info("Scalers salvos em %s", path)
 
     def load(self, path: str | pathlib.Path):
         """Restaura scalers + relatório + metadados já treinados."""
         data = joblib.load(path)
-        self.scalers_  = data['scalers']
-        self.report_   = data.get('report', {})
-        self.strategy  = data.get('strategy', self.strategy)
-        self.random_state = data.get('random_state', self.random_state)
+        self.scalers_ = data["scalers"]
+        self.report_ = data.get("report", {})
+        self.strategy = data.get("strategy", self.strategy)
+        self.random_state = data.get("random_state", self.random_state)
         self.fitted_ = True
         self._fitted = True
         self.logger.info("Scalers carregados de %s", path)

--- a/vassoura/utils.py
+++ b/vassoura/utils.py
@@ -16,8 +16,8 @@ suggest_corr_method – sugere método de correlação ideal
 figsize_from_matrix – ajusta tamanho de figura para heat‑maps
 
 Todas as funções são pensadas para fornecer *logs* detalhados via o
-módulo ``logging``. Para visualizar, no *script* principal configure
-algo como::
+módulo ``logging``. Para visualizar, no *script* principal utilize
+``vassoura.configure_logging`` ou configure manualmente algo como::
 
     import logging, vassoura
     logging.basicConfig(
@@ -43,13 +43,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Configuração de *logger* local
 # ---------------------------------------------------------------------------
-LOGGER = logging.getLogger("vassoura")
-if not LOGGER.handlers:
-    # Evita duplicar handlers quando importado diversas vezes
-    _handler = logging.StreamHandler()
-    _handler.setFormatter(logging.Formatter("%(levelname)s | %(message)s"))
-    LOGGER.addHandler(_handler)
-    LOGGER.setLevel(logging.INFO)
+LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Logging helpers
@@ -85,6 +79,7 @@ def maybe_sample(df: pd.DataFrame, limit: int = 50000) -> pd.DataFrame:
     if len(df) > limit:
         return df.sample(n=limit, random_state=42)
     return df
+
 
 # ---------------------------------------------------------------------------
 # Funções internas auxiliares (não exportadas)

--- a/vassoura/vif.py
+++ b/vassoura/vif.py
@@ -29,7 +29,7 @@ __all__ = [
     "remove_high_vif",
 ]
 
-LOGGER = logging.getLogger("vassoura")
+LOGGER = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Funções internas auxiliares


### PR DESCRIPTION
## Summary
- introduce `logging_utils.configure_logging` helper
- expose `configure_logging` in public API
- document logging setup in README
- refactor modules to use module-level loggers without handlers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6845c62916f48321afe9a444a118e3bf