### PR TITLE
Add BorutaMultiShap heuristic

### DIFF
--- a/vassoura/heuristics.py
+++ b/vassoura/heuristics.py
@@ -27,6 +27,7 @@ import warnings
 
 import pandas as pd
 import numpy as np
+from .heuristics_boruta_multi_shap import BorutaMultiShap
 
 # Dependências opcionais (import inside functions)
 
@@ -40,6 +41,7 @@ __all__ = [
     "perm_importance_lgbm",
     "partial_corr_cluster",
     "drift_vs_target_leakage",
+    "boruta_multi_shap",
 ]
 
 os.environ.setdefault("LIGHTGBM_DISABLE_STDERR_REDIRECT", "1")
@@ -791,3 +793,32 @@ def drift_vs_target_leakage(
         "artefacts": artefacts,
         "meta": {"drift_thr": drift_thr, "leak_thr": leak_thr},
     }
+
+
+# --------------------------------------------------------------------- #
+# Boruta Multi SHAP                                                      #
+# --------------------------------------------------------------------- #
+
+
+def boruta_multi_shap(
+    df: pd.DataFrame,
+    target_col: str,
+    *,
+    n_iter: int = 50,
+    sample_frac: float = 0.7,
+    approval_ratio: float = 0.9,
+    random_state: int | None = None,
+    models: list[dict[str, object]] | None = None,
+    problem: str = "auto",
+    logger: logging.Logger | None = None,
+) -> Dict[str, Any]:
+    """Wrapper for :class:`BorutaMultiShap`."""
+
+    selector = BorutaMultiShap(
+        n_iter=n_iter,
+        sample_frac=sample_frac,
+        approval_ratio=approval_ratio,
+        random_state=random_state,
+        models=models,
+    )
+    return selector(df, target_col, problem=problem, logger=logger)

--- a/vassoura/heuristics_boruta_multi_shap.py
+++ b/vassoura/heuristics_boruta_multi_shap.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import warnings
+import inspect
+from typing import Any, Dict, List
+
+import numpy as np
+import pandas as pd
+
+from sklearn.utils.class_weight import compute_sample_weight
+from sklearn.base import clone
+
+from .scaler import DynamicScaler
+from .utils import woe_encode
+
+
+class BorutaMultiShap:
+    """Boruta-inspired feature selector using multiple models and SHAP values."""
+
+    def __init__(
+        self,
+        n_iter: int = 50,
+        sample_frac: float = 0.7,
+        approval_ratio: float = 0.9,
+        random_state: int | None = None,
+        models: list[dict[str, object]] | None = None,
+    ) -> None:
+        self.n_iter = n_iter
+        self.sample_frac = sample_frac
+        self.approval_ratio = approval_ratio
+        self.random_state = random_state
+        self.models = models
+
+    # ------------------------------------------------------------------
+    def __call__(
+        self,
+        df: pd.DataFrame,
+        target_col: str,
+        *,
+        problem: str = "auto",
+        logger: Any | None = None,
+    ) -> Dict[str, Any]:
+        import shap
+
+        rng = np.random.default_rng(self.random_state)
+        X_full = df.drop(columns=[target_col])
+        y_full = df[target_col]
+
+        # ------------------------------------------------------------------
+        # Determine problem type and sample weights
+        # ------------------------------------------------------------------
+        if problem == "auto":
+            if y_full.nunique() == 2:
+                problem = "binary"
+            else:
+                problem = "reg"
+
+        sample_weight = None
+        if problem == "binary":
+            try:
+                sample_weight = compute_sample_weight("balanced", y_full)
+            except Exception:
+                sample_weight = None
+
+        # ------------------------------------------------------------------
+        # Shadow features
+        # ------------------------------------------------------------------
+        X = X_full.copy()
+        shadow_cols: List[str] = []
+        for col in X_full.columns:
+            sh_col = f"__shadow__{col}"
+            X[sh_col] = rng.permutation(X_full[col].values)
+            shadow_cols.append(sh_col)
+        real_cols = X_full.columns.tolist()
+
+        # ------------------------------------------------------------------
+        # Pre-processing (WoE, fillna, scaling once)
+        # ------------------------------------------------------------------
+        cat_real = X_full.select_dtypes(include=["object", "category"]).columns.tolist()
+        cat_shadow = [f"__shadow__{c}" for c in cat_real]
+        cat_all = cat_real + cat_shadow
+        if cat_all:
+            try:
+                X = woe_encode(X, y_full, cols=cat_all)
+            except Exception:
+                pass
+        X = X.fillna(0)
+
+        if not df.attrs.get("scaled_by_vassoura", False):
+            scaler = DynamicScaler()
+            scaler.fit(X)
+            X = pd.DataFrame(scaler.transform(X), columns=X.columns)
+            df.attrs["scaled_by_vassoura"] = True
+        # if already scaled, keep X as is
+
+        # ------------------------------------------------------------------
+        # Default models
+        # ------------------------------------------------------------------
+        models_cfg = self.models
+        if models_cfg is None:
+            models_cfg = []
+            try:
+                from sklearn.linear_model import LogisticRegression
+
+                if problem == "binary":
+                    models_cfg.append(
+                        {"name": "lr", "estimator": LogisticRegression(max_iter=200)}
+                    )
+            except Exception:
+                warnings.warn("LogisticRegression unavailable")
+
+            try:
+                from xgboost import XGBClassifier, XGBRegressor
+
+                tree_cls = XGBClassifier if problem == "binary" else XGBRegressor
+                models_cfg.append(
+                    {
+                        "name": "xgb",
+                        "estimator": tree_cls(
+                            n_estimators=50,
+                            max_depth=5,
+                            learning_rate=0.1,
+                            subsample=0.8,
+                            eval_metric="logloss" if problem == "binary" else None,
+                            n_jobs=-1,
+                            random_state=self.random_state,
+                        ),
+                    }
+                )
+            except Exception:
+                warnings.warn("XGBoost unavailable")
+
+            try:
+                from lightgbm import LGBMClassifier, LGBMRegressor
+
+                lgbm_cls = LGBMClassifier if problem == "binary" else LGBMRegressor
+                models_cfg.append(
+                    {
+                        "name": "lgbm",
+                        "estimator": lgbm_cls(
+                            n_estimators=50,
+                            max_depth=5,
+                            learning_rate=0.1,
+                            subsample=0.8,
+                            random_state=self.random_state,
+                            n_jobs=-1,
+                            verbosity=-1,
+                        ),
+                    }
+                )
+            except Exception:
+                warnings.warn("LightGBM unavailable")
+
+        # initialise tracking
+        approvals = pd.Series(0, index=real_cols, dtype=float)
+        shap_sums: Dict[str, pd.Series] = {
+            cfg.get("name", str(i)): pd.Series(0.0, index=real_cols)
+            for i, cfg in enumerate(models_cfg)
+        }
+
+        # ------------------------------------------------------------------
+        # Iterations
+        # ------------------------------------------------------------------
+        for _ in range(self.n_iter):
+            idx = rng.choice(len(X), size=int(len(X) * self.sample_frac), replace=True)
+            Xi = X.iloc[idx]
+            yi = y_full.iloc[idx]
+            swi = sample_weight[idx] if sample_weight is not None else None
+
+            for i, cfg in enumerate(models_cfg):
+                name = cfg.get("name", str(i))
+                estimator = clone(cfg.get("estimator"))
+
+                fit_params = {}
+                sig = inspect.signature(estimator.fit)
+                if "sample_weight" in sig.parameters and swi is not None:
+                    fit_params["sample_weight"] = swi
+                elif "class_weight" in sig.parameters and problem == "binary":
+                    try:
+                        estimator.set_params(class_weight="balanced")
+                    except Exception:
+                        fit_params["class_weight"] = "balanced"
+
+                estimator.fit(Xi, yi, **fit_params)
+
+                # SHAP values
+                if name == "lr":
+                    expl = shap.LinearExplainer(estimator, Xi, feature_perturbation="interventional")
+                    sv = expl.shap_values(Xi)
+                    if isinstance(sv, list):
+                        sv = np.stack(sv).sum(axis=0)
+                else:
+                    expl = shap.TreeExplainer(estimator)
+                    sv = expl.shap_values(Xi)
+                    if isinstance(sv, list):
+                        sv = np.stack(sv).sum(axis=0)
+
+                mean_abs = np.abs(sv).mean(axis=0)
+                shap_series = pd.Series(mean_abs, index=Xi.columns)
+                shap_sums[name] = shap_sums[name].add(shap_series[real_cols], fill_value=0)
+                thr = shap_series[shadow_cols].quantile(0.75)
+                winners = shap_series[real_cols] > thr
+                approvals[winners.index] += winners.astype(int)
+
+        approvals_int = approvals.astype(int)
+        approval_prop = approvals / self.n_iter
+        kept = approval_prop[approval_prop >= self.approval_ratio].index.tolist()
+        removed = approval_prop[approval_prop < self.approval_ratio / 2].index.tolist()
+
+        shap_mean_by_model = {
+            name: series / self.n_iter for name, series in shap_sums.items()
+        }
+        shap_df = pd.DataFrame(shap_mean_by_model)
+
+        meta = {
+            "n_iter": self.n_iter,
+            "sample_frac": self.sample_frac,
+            "approval_ratio": self.approval_ratio,
+            "random_state": self.random_state,
+            "models_used": list(shap_mean_by_model.keys()),
+        }
+
+        artefacts = {
+            "shap_mean_by_model": shap_df,
+            "approvals": approvals_int,
+        }
+
+        return {"kept": kept, "removed": removed, "artefacts": artefacts, "meta": meta}

--- a/vassoura/relatorio.py
+++ b/vassoura/relatorio.py
@@ -432,6 +432,11 @@ def generate_report(
         if "__noise_uniform__" not in df_clean.columns:
             np.random.seed(0)
             df_clean["__noise_uniform__"] = np.random.rand(len(df_clean))
+        if "__shadow__" not in df_clean.columns:
+            df_clean["__shadow__"] = df_clean["__noise_uniform__"]
+        if "__shadow__" not in df_clean.columns:
+            np.random.seed(1)
+            df_clean["__shadow__"] = np.random.rand(len(df_clean))
 
         def _compute_ks(s: pd.Series, target: pd.Series, n_bins: int = 10) -> float:
             if s.dtype.kind in "bifc" and s.nunique() > 1:
@@ -459,6 +464,8 @@ def generate_report(
         ks_s = ks_s.sort_values(ascending=False)
 
         X = df_clean[cols_eval]
+        if "__noise_uniform__" in X.columns and "__shadow__" in X.columns:
+            X = X.drop(columns=["__noise_uniform__"])
         X = X.apply(lambda s: s.astype("category") if s.dtype == "object" else s)
         model = LGBMClassifier(
             n_estimators=100,

--- a/vassoura/tests/run_tests.sh
+++ b/vassoura/tests/run_tests.sh
@@ -14,6 +14,8 @@ pytest -vv --tb=long vassoura/tests/test_session.py                             
 pytest -vv --tb=long vassoura/tests/test_special_cols.py                         > vassoura/tests/test_results/test_special_cols.txt
 pytest -vv --tb=long vassoura/tests/test_utils.py                                > vassoura/tests/test_results/test_utils.txt
 pytest -vv --tb=long vassoura/tests/test_variance.py                             > vassoura/tests/test_results/test_variance.txt
+pytest -vv --tb=long vassoura/tests/test_boruta_multi_shap.py 
+ > vassoura/tests/test_results/test_boruta_multi_shap.txt
 pytest -vv --tb=long vassoura/tests/test_vassoura_integration_super.py           > vassoura/tests/test_results/test_vassoura_integration_super.txt
 pytest -vv --tb=long vassoura/tests/test_vif.py                                  > vassoura/tests/test_results/test_vif.txt
 

--- a/vassoura/tests/test_boruta_multi_shap.py
+++ b/vassoura/tests/test_boruta_multi_shap.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import numpy as np
+
+from vassoura.heuristics import boruta_multi_shap
+
+
+def test_boruta_multi_shap_basic():
+    rng = np.random.default_rng(0)
+    n = 100
+    x1 = rng.normal(size=n)
+    x_noise = rng.normal(size=n)
+    target = (x1 + rng.normal(scale=0.3, size=n) > 0).astype(int)
+    df = pd.DataFrame({"x1": x1, "x_noise": x_noise, "target": target})
+
+    result = boruta_multi_shap(df, "target", n_iter=1, sample_frac=0.8, random_state=0)
+    assert set(result["kept"] + result["removed"]) == {"x1", "x_noise"}
+    assert "approvals" in result["artefacts"]
+
+
+def test_boruta_multi_shap_respects_scaled_flag():
+    rng = np.random.default_rng(1)
+    df = pd.DataFrame({"x": rng.normal(size=50), "target": rng.integers(0, 2, 50)})
+    df.attrs["scaled_by_vassoura"] = True
+    result = boruta_multi_shap(df, "target", n_iter=1, sample_frac=0.8, random_state=0)
+    assert df.attrs["scaled_by_vassoura"]
+    assert isinstance(result["meta"], dict)
+
+
+def test_boruta_multi_shap_class_imbalance():
+    rng = np.random.default_rng(2)
+    x1 = rng.normal(size=200)
+    target = (rng.random(200) > 0.95).astype(int)
+    df = pd.DataFrame({"x1": x1, "target": target})
+    result = boruta_multi_shap(df, "target", n_iter=1, sample_frac=0.8, random_state=0)
+    assert isinstance(result["meta"], dict)
+
+


### PR DESCRIPTION
## Summary
- implement `BorutaMultiShap` heuristic with SHAP approval voting
- expose wrapper in heuristics module
- integrate basic tests and run script update
- ensure noise uniform analysis provides a shadow column

## Testing
- `bash vassoura/tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845fdda03508321b5015ffe5b83134a