### PR TITLE
Enable Boruta Multi SHAP in Vassoura

### DIFF
--- a/vassoura/tests/test_boruta_multi_shap.py
+++ b/vassoura/tests/test_boruta_multi_shap.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import numpy as np
+from vassoura.core import Vassoura
 
 from vassoura.heuristics import boruta_multi_shap
 
@@ -35,3 +36,21 @@ def test_boruta_multi_shap_class_imbalance():
     assert isinstance(result["meta"], dict)
 
 
+def test_boruta_multi_shap_vassoura_integration():
+    rng = np.random.default_rng(3)
+    x1 = rng.normal(size=120)
+    x_noise = rng.normal(size=120)
+    target = (x1 + rng.normal(scale=0.3, size=120) > 0).astype(int)
+    df = pd.DataFrame({"x1": x1, "x_noise": x_noise, "target": target})
+
+    vs = Vassoura(
+        df,
+        target_col="target",
+        heuristics=["boruta_multi_shap"],
+        params={
+            "boruta_multi_shap": {"n_iter": 1, "sample_frac": 0.8, "random_state": 3}
+        },
+    )
+    out = vs.run()
+    assert out.shape[1] <= df.shape[1]
+    assert any(step["reason"] == "boruta_multi_shap" for step in vs.history)


### PR DESCRIPTION
## Summary
- register the new `boruta_multi_shap` heuristic
- implement `_apply_boruta_multi_shap` in the cleaning session
- keep heuristic result in session state
- add an integration test for the heuristic

## Testing
- `pytest -k boruta_multi_shap_vassoura_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_6846096552b88321a4574da1cfe29023