### PR TITLE
Enhance adaptive sampling

### DIFF
--- a/vassoura/correlacao.py
+++ b/vassoura/correlacao.py
@@ -173,7 +173,11 @@ def compute_corr_matrix(
             )
         data = df_work[num_cols].copy()
         if adaptive_sampling:
-            data = maybe_sample(data)
+            data = maybe_sample(
+                data,
+                stratify_col=target_col,
+                date_cols=date_col,
+            )
         corr_engine = engine
         if engine == "dask":
             try:
@@ -220,7 +224,11 @@ def compute_corr_matrix(
             raise ValueError("Não há colunas categóricas para calcular Cramér‑V")
         data = df_work[cat_cols].copy()
         if adaptive_sampling:
-            data = maybe_sample(data)
+            data = maybe_sample(
+                data,
+                stratify_col=target_col,
+                date_cols=date_col,
+            )
         corr = _cramers_v_matrix(data)
         if verbose:
             LOGGER.info(

--- a/vassoura/tests/test_utils.py
+++ b/vassoura/tests/test_utils.py
@@ -1,5 +1,11 @@
 import pandas as pd
-from vassoura.utils import suggest_corr_method, figsize_from_matrix, criar_dataset_pd_behavior
+import pytest
+from vassoura.utils import (
+    suggest_corr_method,
+    figsize_from_matrix,
+    criar_dataset_pd_behavior,
+    maybe_sample,
+)
 
 def test_suggest_corr_method():
     assert suggest_corr_method(["a", "b"], []) == "pearson"
@@ -18,3 +24,20 @@ def test_criar_dataset_pd_behavior_columns():
     assert expected_cols <= set(df.columns)
     # AnoMesReferencia deve estar no formato YYYYMM (int)
     assert df["AnoMesReferencia"].dtype == int
+
+
+def test_maybe_sample_stratify_and_order():
+    df = pd.DataFrame({
+        "target": [0] * 80 + [1] * 20,
+        "date": pd.date_range("2020-01-01", periods=100, freq="D"),
+    })
+    sampled = maybe_sample(
+        df,
+        max_cells=40,
+        stratify_col="target",
+        date_cols=["date"],
+        random_state=0,
+    )
+    assert len(sampled) == 20
+    assert sampled["target"].mean() == pytest.approx(df["target"].mean())
+    assert sampled["date"].is_monotonic_increasing

--- a/vassoura/vif.py
+++ b/vassoura/vif.py
@@ -140,7 +140,11 @@ def compute_vif(
             rows_before - rows_after,
         )
     if adaptive_sampling:
-        data = maybe_sample(data)
+        data = maybe_sample(
+            data,
+            stratify_col=target_col,
+            date_cols=date_col,
+        )
 
     if engine == "dask":
         try:


### PR DESCRIPTION
## Summary
- update adaptive sampling function in utils
- add adaptive sampling process step in core
- keep sample across heuristics and default to target stratification
- document adaptive sampling and extend example
- add tests for `maybe_sample`

## Testing
- `pip install pandas`
- `pip install -e .`
- `pytest -vv vassoura/tests/test_utils.py -k maybe_sample_stratify_and_order` *(fails: ModuleNotFoundError: No module named 'joblib')*


------
https://chatgpt.com/codex/tasks/task_e_68465b1392a88321a0ae78ee7500d98b