### PR TITLE
Fix correlation heatmap and remove old manager

### DIFF
--- a/vassoura/__init__.py
+++ b/vassoura/__init__.py
@@ -5,7 +5,6 @@ from .analisador import analisar_autocorrelacao
 from .autocorrelacao import compute_panel_acf, plot_panel_acf
 from .core import Vassoura
 from .correlacao import compute_corr_matrix, plot_corr_heatmap
-from .corr_manager import CorrelationManager
 from .limpeza import clean
 from .logging_utils import configure_logging
 from .relatorio import generate_report
@@ -25,7 +24,6 @@ __all__ = [
     "criar_dataset_pd_behavior",
     "compute_corr_matrix",
     "plot_corr_heatmap",
-    "CorrelationManager",
     "compute_vif",
     "remove_high_vif",
     "target_leakage",

--- a/vassoura/correlacao.py
+++ b/vassoura/correlacao.py
@@ -185,6 +185,18 @@ def compute_corr_matrix(
         num_cols = num_cols + cat_cols
         cat_cols = []
 
+    # ------------------------------------------------------------------
+    # Remove colunas constantes que inviabilizam a correlação
+    # ------------------------------------------------------------------
+    cols_check = num_cols + cat_cols
+    const_cols = [c for c in cols_check if df_work[c].nunique(dropna=False) <= 1]
+    if const_cols:
+        if verbose:
+            LOGGER.info("Ignorando colunas constantes na correlação: %s", const_cols)
+        df_work = df_work.drop(columns=const_cols)
+        num_cols = [c for c in num_cols if c not in const_cols]
+        cat_cols = [c for c in cat_cols if c not in const_cols]
+
     # Escolha automática do método para variáveis numéricas
     numeric_method = method
     if method == "auto":

--- a/vassoura/relatorio.py
+++ b/vassoura/relatorio.py
@@ -34,7 +34,6 @@ import pandas as pd
 import seaborn as sns
 
 from .correlacao import compute_corr_matrix, plot_corr_heatmap
-from .corr_manager import CorrelationManager
 from .limpeza import clean
 from .utils import figsize_from_matrix, search_dtypes, suggest_corr_method
 from .vif import compute_vif
@@ -610,7 +609,7 @@ def generate_report(
                 corr_after,
                 title="Correlação pós-limpeza (Spearman)",
                 ax=ax_can,
-                annot=False,
+                annot=True,
                 fmt=".2f",
                 highlight_labels=False,
             )


### PR DESCRIPTION
## Summary
- ignore constant columns when computing correlation
- drop unused CorrelationManager from API
- show annotations on final Noise Uniform heatmap

## Testing
- `pytest -qq vassoura/tests/test_correlacao.py`
- `bash vassoura/tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847318c45008321aac27ef39d727fa3