### PR TITLE
Add temporary WOE encoding for VIF

### DIFF
--- a/vassoura/tests/test_core.py
+++ b/vassoura/tests/test_core.py
@@ -78,8 +78,8 @@ def test_compute_corr_matrix():
 def test_compute_vif():
     df = _make_dummy_df()
     vif = vs.compute_vif(df, target_col="target", verbose="none")
-    # Deve existir uma linha por variável numérica
-    assert set(vif["variable"]) == {"x1", "x2", "x3"}
+    # Deve existir uma linha por variável analisada (numéricas + categóricas codificadas)
+    assert set(vif["variable"]) == {"x1", "x2", "x3", "cat"}
     # x1 ou x2 devem ter VIF alto devido à correlação
     assert vif["vif"].max() > 5
 

--- a/vassoura/tests/test_vif.py
+++ b/vassoura/tests/test_vif.py
@@ -21,3 +21,15 @@ def test_vif_values_reasonable():
     df = _make_vif_data()
     result = compute_vif(df, target_col="target", verbose="none")
     assert result["vif"].max() > 5, "Esperado VIF alto por causa da correlação entre x1 e x2"
+
+
+def test_vif_with_categorical_and_nan():
+    df = pd.DataFrame(
+        {
+            "num1": [1, 2, 3, 4, 5, 6],
+            "cat1": ["a", "b", "a", None, "b", "c"],
+            "target": [0, 1, 0, 1, 0, 1],
+        }
+    )
+    result = compute_vif(df, target_col="target", limite_categorico=10, verbose="none")
+    assert set(result["variable"]) == {"num1", "cat1"}


### PR DESCRIPTION
## Summary
- encode categorical columns with WoE when computing VIF
- treat missing values as a distinct category
- test new behaviour with NaNs
- update VIF expectations in core tests

## Testing
- `pytest -q vassoura/tests/test_core.py`
- `pytest -q vassoura/tests/test_vif.py`


------
https://chatgpt.com/codex/tasks/task_e_68475b725220832190aa3a0792488295