### PR TITLE
Implement WoE preprocessing for graph_cut heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Para configurar os logs de todo o pacote basta executar::
 | **`Vassoura` (classe)** | Sessão *stateful* que concentra todo o fluxo de limpeza   | cache inteligente, logs granulares, suporte a `id_cols`, `date_cols`, `ignore_cols`, remoção fracionada (`n_steps`, `vif_n_steps`) |
 | **Correlação**          | `compute_corr_matrix`, `plot_corr_heatmap`                | Pearson ou Spearman com codificação WoE temporária; *heat‑maps* auto‑dimensionados                                                 |
 | **VIF**                 | `compute_vif`, `remove_high_vif`                          | Algoritmo NumPy puro (fallback) ou Statsmodels; compatível com `polars` e `dask`                                                   |
-| **Heurísticas Plug‑in** | `corr`, `vif`, `iv`, `importance`, `graph_cut`, `missing`, `variance` | escolha via parâmetro; **graph‑cut** resolve correlações complexas em grafo mínimo                                                 |
+| **Heurísticas Plug‑in** | `corr`, `vif`, `iv`, `importance`, `graph_cut`, `missing`, `variance` | escolha via parâmetro; **graph‑cut** resolve correlações complexas em grafo mínimo com WoE temporário |
 | **Relatórios**          | `generate_report`                                         | HTML ou Markdown com seções ilustradas, imagens embutidas, lista de variáveis removidas                                            |
 | **Autocorrelação**      | `compute_panel_acf`, `analisar_autocorrelacao`            | ACF por painel (contrato, cliente, etc.) com interpretação automática                                                              |
 

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -11,9 +11,11 @@ Train a light XGBoost model and drop the lowest scoring features using SHAP gain
 Categorical columns are automatically encoded via a lightweight WOE scheme.
 Requires `xgboost` and `shap` installed.
 
-### `graph_cut(df, corr_threshold=0.9, keep_cols=None, method='pearson')`
+### `graph_cut(df, corr_threshold=0.9, keep_cols=None, method='pearson', target_col=None)`
 Build a correlation graph and compute a minimal vertex cover to determine
-which variables to drop.
+which variables to drop. Categorical columns are temporarily WOE encoded
+(missing values treated as their own category) when a binary `target_col`
+is provided.
 
 ### `variance(df, var_threshold=1e-4, dom_threshold=0.95, min_nonnull=30, keep_cols=None)`
 Drop features with very low numerical variance or with a single dominant

--- a/vassoura/tests/test_graph_cut.py
+++ b/vassoura/tests/test_graph_cut.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+from vassoura.heuristics import graph_cut
+
+
+def test_graph_cut_with_categorical_nan():
+    df = pd.DataFrame(
+        {
+            "num": [0, 0, 1, 1, 1, 1],
+            "cat": ["a", "a", None, "b", "b", None],
+            "target": [0, 0, 1, 1, 1, 1],
+        }
+    )
+    result = graph_cut(df, target_col="target", corr_threshold=0.9)
+    removed = result["removed"]
+    assert any(col in removed for col in ["num", "cat"])


### PR DESCRIPTION
## Summary
- add optional `target_col` param to `graph_cut`
- perform temporary WoE encoding with nulls as category inside `graph_cut`
- adjust `_apply_graph_cut` to send target column and handle any dtype
- document new behaviour in README and heuristics docs
- add regression test for categorical support in `graph_cut`

## Testing
- `bash vassoura/tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6847658937008321bfa7ba77b1fddf8f