### PR TITLE
Fix packaging path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "scipy>=1.11",
     "statsmodels>=0.14",
     "networkx>=3.2",
+    "scikit-learn>=1.4",
 ]
 
 classifiers = [
@@ -39,7 +40,6 @@ dev = ["pytest", "coverage", "pre-commit", "black", "isort"]
 docs = ["mkdocs-material"]
 
 [tool.setuptools.packages.find]
-where = ["vassoura"]
 include = ["vassoura*"]
 
 [tool.setuptools]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ mplcursors==0.6
 shap>=0.47
 lightgbm>=4.0
 networkx>=3.2
+scikit-learn>=1.4


### PR DESCRIPTION
## Summary
- ensure setuptools finds packages from project root
- add scikit-learn as requirement

## Testing
- `pip install shap==0.47`
- `pip install lightgbm==4.2.0`
- `pytest -q` *(fails: test_psi_stability_detects_drift, test_all_artefacts_present)*

------
https://chatgpt.com/codex/tasks/task_e_6847901230d48321a494da8ab932efa9