### PR TITLE
Add cooperative heuristic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,11 @@ vs = Vassoura(
     n_steps=5,
     vif_n_steps=2,
     timeout_map={"importance": 90, "graph_cut": 60},
+    chunk_size=25,
     max_total_runtime=600,
 )
 
-df_clean = vs.run(recompute=True)
+df_clean = vs.run_all()
 
 vs.generate_report("relatorio_corr.html")
 ```

--- a/vassoura/base_heuristic.py
+++ b/vassoura/base_heuristic.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterator, Sequence, List
+
+import pandas as pd
+
+
+def chunk_iter(seq: Sequence[str], size: int) -> Iterator[List[str]]:
+    """Yield successive chunks from *seq* of length *size*."""
+    for i in range(0, len(seq), size):
+        yield list(seq[i : i + size])
+
+
+class BaseHeuristic(ABC):
+    """Abstract base class for cooperative heuristics."""
+
+    @abstractmethod
+    def run(
+        self,
+        df: pd.DataFrame,
+        *,
+        budget_sec: float | None = None,
+        chunk_size: int = 50,
+    ) -> List[str]:
+        """Return columns to drop. Implementation must respect *budget_sec*."""
+        raise NotImplementedError

--- a/vassoura/cooperative_vif.py
+++ b/vassoura/cooperative_vif.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import math
+import time
+from typing import List
+
+import pandas as pd
+
+from .base_heuristic import BaseHeuristic
+from .vif import compute_vif
+
+
+class CooperativeVIF(BaseHeuristic):
+    """Iterative VIF heuristic respecting a time budget."""
+
+    def __init__(self, session) -> None:
+        self.session = session
+
+    def run(
+        self,
+        df: pd.DataFrame,
+        *,
+        budget_sec: float | None = None,
+        chunk_size: int = 50,
+    ) -> List[str]:
+        start = time.perf_counter()
+        thr = self.session.params.get("vif", 10.0)
+        work = df.copy()
+        removed: List[str] = []
+        while True:
+            if budget_sec is not None and time.perf_counter() - start >= budget_sec:
+                break
+            vif_df = compute_vif(
+                work,
+                target_col=self.session.target_col,
+                include_target=False,
+                engine=self.session.engine,
+                verbose=self.session.verbose,
+            )
+            worst = vif_df[vif_df["vif"] > thr]
+            if worst.empty:
+                break
+            step_limit = (
+                1
+                if self.session.vif_n_steps == 1
+                else max(1, math.ceil(len(worst) / self.session.vif_n_steps))
+            )
+            for _, row in worst.sort_values("vif", ascending=False).iterrows():
+                col = row["variable"]
+                if col not in self.session.keep_cols and col in work.columns:
+                    removed.append(col)
+                    work = work.drop(columns=[col])
+                    step_limit -= 1
+                    if step_limit == 0:
+                        break
+                if budget_sec is not None and time.perf_counter() - start >= budget_sec:
+                    break
+        return removed

--- a/vassoura/core.py
+++ b/vassoura/core.py
@@ -420,6 +420,11 @@ class Vassoura:
                 )
         return self.df_current
 
+    # --------------------------------------------------------------
+    def run_all(self, **kwargs) -> pd.DataFrame:
+        """Backward compatible alias for ``run()``."""
+        return self.run(**kwargs)
+
     def remove_additional(self, columns: List[str]) -> None:
         """Força remoção manual de colunas pós-limpeza."""
         self._drop(columns, reason="manual")

--- a/vassoura/tests/test_timeout_cooperative.py
+++ b/vassoura/tests/test_timeout_cooperative.py
@@ -1,0 +1,57 @@
+import time
+import pandas as pd
+
+from vassoura.base_heuristic import BaseHeuristic, chunk_iter
+from vassoura.core import Vassoura
+
+
+class SlowHeuristic(BaseHeuristic):
+    def run(
+        self, df: pd.DataFrame, *, budget_sec: float | None = None, chunk_size: int = 1
+    ) -> list[str]:
+        start = time.perf_counter()
+        drops: list[str] = []
+        for cols in chunk_iter(df.columns, chunk_size):
+            if cols[0] == "target":
+                continue
+            time.sleep(0.02)
+            if budget_sec is not None and time.perf_counter() - start >= budget_sec:
+                break
+            drops.extend([c for c in cols if c != "target"])
+        return drops
+
+
+def _base_df() -> pd.DataFrame:
+    return pd.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6], "target": [0, 1]})
+
+
+def test_happy_path():
+    df = _base_df()
+    h = SlowHeuristic()
+    removed = h.run(df, budget_sec=1)
+    assert set(removed) == {"a", "b", "c"}
+
+
+def test_timeout_partial():
+    df = _base_df()
+    h = SlowHeuristic()
+    removed = h.run(df, budget_sec=0.05, chunk_size=1)
+    assert 0 < len(removed) < 3
+
+
+def test_pipeline_applies_partial_result():
+    df = _base_df()
+    h = SlowHeuristic()
+    vs = Vassoura(
+        df,
+        target_col="target",
+        heuristics=["dummy"],
+        process=["scaler"],
+        timeout_map={"dummy": 0.05},
+        verbose="none",
+    )
+    vs._heuristic_funcs["dummy"] = lambda: df.drop(
+        columns=h.run(vs.df_current, budget_sec=0.05, chunk_size=1), inplace=True
+    )
+    result = vs.run()
+    assert result.shape[1] <= 4


### PR DESCRIPTION
## Summary
- add `BaseHeuristic` base class with `chunk_iter`
- document `run_all` usage in README
- expose `run_all` alias in core
- add cooperative VIF example heuristic
- test cooperative timeout logic

## Testing
- `pytest -q vassoura/tests/test_timeout_cooperative.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shap')*

------
https://chatgpt.com/codex/tasks/task_e_6847ab9996f08321a9e784bbde5eb67e