### PR TITLE
Implement Boruta column batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ vs = Vassoura(
         "boruta_estimators": 30,
         "boruta_max_depth": 4,
         "boruta_fast_mode": False,
+        "boruta_n_batches": 5,
     },
     n_steps=5,
     vif_n_steps=2,
@@ -143,6 +144,10 @@ vs.generate_report("relatorio_corr.html")
 `timeout_map` define limites (em segundos) por heurística. Caso o passo
 extrapole o tempo, ele é pulado sem interromper o fluxo. Já `max_total_runtime`
 encerra o `run()` quando o orçamento global é excedido.
+
+`boruta_n_batches` permite dividir as features em lotes balanceados antes de rodar
+a heurística Boruta Multi SHAP, reduzindo consumo de memória e tempo sem perder
+representatividade.
 
 ### 2. Limpeza funcional (atalho)
 

--- a/docs/heuristics.md
+++ b/docs/heuristics.md
@@ -38,3 +38,13 @@ Detect features highly correlated with both the date column and the target (pote
 
 ### `target_leakage(df, target_col, threshold=0.8, method='spearman', keep_cols=None, id_cols=None, date_cols=None)`
 Highlight columns with very high absolute correlation with the target, indicating possible data leakage.
+
+### `boruta_multi_shap(df, target_col, n_iter=50, sample_frac=0.7, approval_ratio=0.9, n_batches=None, ...)`
+Run a Boruta-style selector using multiple models and SHAP values. When
+`n_batches` is specified the columns are divided into smart batches using
+`build_feature_batches` to reduce memory usage while keeping a representative
+mix of features.
+
+### `build_feature_batches(df, target_col, n_batches=5, quick_gain=True, corr_balance=True, random_state=42)`
+Utility helper to create balanced feature batches combining cost-aware binning,
+a quick LightGBM ranking and a correlation-based round robin spread.

--- a/vassoura/tests/test_boruta_multi_shap.py
+++ b/vassoura/tests/test_boruta_multi_shap.py
@@ -65,3 +65,23 @@ def test_boruta_multi_shap_fast_mode():
     })
     result = boruta_multi_shap(df, "target", fast_mode=True, random_state=4)
     assert "timings" in result["artefacts"]
+
+
+def test_boruta_multi_shap_batches():
+    rng = np.random.default_rng(5)
+    df = pd.DataFrame({
+        "a": rng.normal(size=60),
+        "b": rng.normal(size=60),
+        "c": rng.normal(size=60),
+        "target": (rng.normal(size=60) > 0).astype(int),
+    })
+    result = boruta_multi_shap(
+        df,
+        "target",
+        n_iter=1,
+        sample_frac=0.8,
+        random_state=5,
+        n_batches=2,
+    )
+    assert result["meta"]["n_batches"] == 2
+    assert "batches" in result["artefacts"]


### PR DESCRIPTION
## Summary
- implement `build_feature_batches` with cost, importance and correlation balancing
- allow `boruta_multi_shap` to run in batches via new parameter `n_batches`
- document new options in README and docs
- add unit test for batched Boruta run

## Testing
- `pytest vassoura/tests/test_boruta_multi_shap.py::test_boruta_multi_shap_batches -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b9d532708321a84cc7fb6fb51c2c