### PR TITLE
Fix sample df not updated in VIF heuristic

### DIFF
--- a/vassoura/core.py
+++ b/vassoura/core.py
@@ -1034,6 +1034,8 @@ class Vassoura:
         if not cols:
             return
         self.df_current.drop(columns=cols, errors="ignore", inplace=True)
+        if self._sample_df is not None:
+            self._sample_df.drop(columns=cols, errors="ignore", inplace=True)
         entry = {"cols": cols, "reason": reason}
         if values is not None:
             entry["values"] = values


### PR DESCRIPTION
## Summary
- sync adaptive sample with main DataFrame when dropping columns

## Testing
- `pytest -q vassoura/tests/test_heuristics.py`
- `pytest -q vassoura/tests/test_graph_cut.py`
- `pytest -q vassoura/tests/test_timeout_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68482eb3e19c8321913979854117df5a