### PR TITLE
Fix correlation on empty DataFrame

### DIFF
--- a/vassoura/correlacao.py
+++ b/vassoura/correlacao.py
@@ -145,6 +145,11 @@ def compute_corr_matrix(
     drop_target = target_col and not include_target
     df_work = df.drop(columns=[target_col], errors="ignore") if drop_target else df.copy()
 
+    if df_work.empty:
+        if verbose:
+            LOGGER.info("Matriz de correlação ignorada (DataFrame vazio)")
+        return pd.DataFrame()
+
     num_cols, cat_cols = search_dtypes(
         df_work,
         target_col=None,


### PR DESCRIPTION
## Summary
- avoid crash in `compute_corr_matrix` when DataFrame is empty

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684834eddd948321853795ad628c811f