### PR TITLE
Fix VIF on empty data and robust heuristics

### DIFF
--- a/vassoura/tests/test_vif.py
+++ b/vassoura/tests/test_vif.py
@@ -124,3 +124,10 @@ def test_vif_no_numeric_columns_raises():
     # Definimos limite_categorico=0 → impede fallback automático
     with pytest.raises(ValueError):
         compute_vif(df, target_col="target", limite_categorico=0, verbose="none")
+
+
+def test_vif_all_inf_returns_nan():
+    """DataFrames que ficam vazios após remoção de inf devem retornar NaN."""
+    df = pd.DataFrame({"x": [np.inf, np.inf], "target": [0, 1]})
+    vif = compute_vif(df, target_col="target", verbose="none")
+    assert vif["vif"].isna().all()

--- a/vassoura/vif.py
+++ b/vassoura/vif.py
@@ -133,6 +133,15 @@ def compute_vif(
         .dropna()
     )
 
+    if data.empty:
+        warnings.warn(
+            "Nenhuma linha válida disponível para VIF; retornando NaN",
+            RuntimeWarning,
+        )
+        return pd.DataFrame(
+            {"variable": num_cols, "vif": [np.nan for _ in num_cols]}
+        )
+
     if adaptive_sampling:
         data = _adaptive_sampling(data, stratify_col=target_col, date_cols=date_col)
 


### PR DESCRIPTION
## Summary
- avoid crashing when compute_vif finds no valid rows
- make partial_corr_cluster ignore non‑numeric or constant columns
- compute PSI stability bins consistently across windows
- add regression test for compute_vif with all infinite data

## Testing
- `pytest vassoura/tests/test_vif.py::test_vif_all_inf_returns_nan -q`
- `pytest vassoura/tests/test_heuristics.py::test_psi_stability_detects_drift -q`
- `pytest vassoura/tests/test_heuristics.py::test_all_artefacts_present -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483cff144c8321bb7d9579f4fc8eb4