### PR TITLE
Implement simple cross-validation utilities

### DIFF
--- a/vassoura/tests/test_cv.py
+++ b/vassoura/tests/test_cv.py
@@ -1,0 +1,29 @@
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+
+from vassoura.validation.cv import CrossValidator, cross_validate
+
+
+def test_cross_validator_stratified():
+    X, y = make_classification(n_samples=100, n_features=5, random_state=0)
+    cv = CrossValidator(cv_type="stratified", n_splits=3, random_state=0)
+    splits = list(cv.split(X, y))
+    assert len(splits) == 3
+    base_rate = y.mean()
+    for _, test_idx in splits:
+        assert abs(y[test_idx].mean() - base_rate) < 0.1
+
+
+def test_cross_validate_simple():
+    X, y = make_classification(n_samples=50, n_features=4, random_state=1)
+    est = LogisticRegression(max_iter=200)
+    cv = CrossValidator(cv_type="stratified", n_splits=3, random_state=0)
+
+    scoring = {"acc": lambda est, X, y: accuracy_score(y, est.predict(X))}
+    res = cross_validate(est, X, y, cv=cv, scoring=scoring)
+
+    assert set(res) == {"train_acc", "test_acc"}
+    assert len(res["train_acc"]) == 3
+    assert all(isinstance(v, float) for v in res["test_acc"])

--- a/vassoura/validation/__init__.py
+++ b/vassoura/validation/__init__.py
@@ -1,0 +1,5 @@
+"""Cross-validation utilities for Vassoura."""
+
+from .cv import CrossValidator, cross_validate
+
+__all__ = ["CrossValidator", "cross_validate"]

--- a/vassoura/validation/cv.py
+++ b/vassoura/validation/cv.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Minimal cross-validation helpers."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Iterator, Sequence
+
+import numpy as np
+from sklearn.base import BaseEstimator, clone
+from sklearn.model_selection import StratifiedKFold, TimeSeriesSplit
+
+
+@dataclass
+class CrossValidator:
+    """Wrapper around a sklearn splitter."""
+
+    cv_type: str = "stratified"
+    n_splits: int = 5
+    shuffle: bool = True
+    random_state: int = 42
+
+    def _make_splitter(self, y=None):
+        if self.cv_type == "stratified":
+            return StratifiedKFold(
+                n_splits=self.n_splits,
+                shuffle=self.shuffle,
+                random_state=self.random_state,
+            )
+        if self.cv_type == "time_series":
+            return TimeSeriesSplit(n_splits=self.n_splits)
+        raise ValueError(f"Unknown cv_type: {self.cv_type}")
+
+    def split(self, X: Sequence, y: Sequence | None = None) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        splitter = self._make_splitter(y)
+        if isinstance(splitter, StratifiedKFold):
+            return splitter.split(X, y)
+        return splitter.split(X)
+
+    def get_n_splits(self, X: Sequence | None = None, y: Sequence | None = None) -> int:
+        splitter = self._make_splitter(y)
+        return splitter.get_n_splits(X, y)
+
+
+def _take(data: Sequence, idx: Iterable[int]):
+    if hasattr(data, "iloc"):
+        return data.iloc[list(idx)]
+    return data[list(idx)]
+
+
+def cross_validate(
+    estimator: BaseEstimator,
+    X: Sequence,
+    y: Sequence,
+    *,
+    cv: CrossValidator | None = None,
+    scoring: Dict[str, Callable[[BaseEstimator, Sequence, Sequence], float]] | None = None,
+) -> Dict[str, list[float]]:
+    """Run cross validation and return metrics."""
+
+    cv = cv or CrossValidator()
+    if scoring is None:
+        scoring = {"score": lambda est, X_, y_: est.score(X_, y_)}
+
+    results: Dict[str, list[float]] = {}
+    for name in scoring:
+        results[f"train_{name}"] = []
+        results[f"test_{name}"] = []
+
+    for train_idx, test_idx in cv.split(X, y):
+        est = clone(estimator)
+        X_train, y_train = _take(X, train_idx), _take(y, train_idx)
+        X_test, y_test = _take(X, test_idx), _take(y, test_idx)
+        est.fit(X_train, y_train)
+        for name, func in scoring.items():
+            results[f"train_{name}"].append(func(est, X_train, y_train))
+            results[f"test_{name}"].append(func(est, X_test, y_test))
+
+    return results


### PR DESCRIPTION
## Summary
- add `validation` module with `CrossValidator` and `cross_validate`
- expose helpers in package
- test stratified splitting and metric collection

## Testing
- `pytest vassoura/tests/test_cv.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e502fe888321a10786b366a4533a