### PR TITLE
Add verbose levels and summary for DynamicScaler

### DIFF
--- a/vassoura/scaler.py
+++ b/vassoura/scaler.py
@@ -47,6 +47,10 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
         Logger customizado; se None, usa ``vassoura.scaler``.
     log_level : int | None
         Nível de log a ser aplicado ao logger.
+    verbose : {'off', 'basic', 'debug'}
+        Controla o nível de mensagens impressas durante ``fit`` e ``transform``.
+        ``"off"`` desativa logs, ``"basic"`` mostra progresso e ``"debug"``
+        detalha coluna a coluna.
     enable_scaler : bool
         Se False, ``transform`` devolve o DataFrame inalterado.
     """
@@ -62,7 +66,7 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
         save_path: str | pathlib.Path | None = None,
         random_state: int = 0,
         *,
-        verbose: str = "none",
+        verbose: str = "off",
         log_level: int | None = None,
         logger: logging.Logger | None = None,
         enable_scaler: bool = True,
@@ -235,6 +239,14 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
         self.fitted_ = True
         self._fitted = True
         if self.verbose in ("basic", "debug"):
+            applied = {
+                col: (scaler.__class__.__name__ if scaler else "None")
+                for col, scaler in self.scalers_.items()
+            }
+            self.logger.info(
+                "[DynamicScaler] %s",
+                pd.Series(applied).value_counts().to_dict(),
+            )
             elapsed = time.time() - start_time
             self.logger.info("[DynamicScaler] fit completed in %.2fs", elapsed)
         return self


### PR DESCRIPTION
## Summary
- enhance `DynamicScaler` with new verbose levels
- log a summary of scalers at the end of `fit`

## Testing
- `pytest vassoura/tests/test_scaler.py vassoura/tests/test_utils.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named '...')*

------
https://chatgpt.com/codex/tasks/task_e_6848e65087908321b91cc448b3fb1f3f