### PR TITLE
Add WOE encoder and default pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,18 @@ scaler = DynamicScaler(strategy="auto")
 X_scaled = scaler.fit_transform(X_sampled)
 ```
 
+
+### Example – Quick modelling
+
+```python
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from vassoura.preprocessing import make_default_pipeline
+
+pipeline = make_default_pipeline()
+model = Pipeline([
+    ("prep", pipeline),
+    ("clf", LogisticRegression())
+])
+model.fit(X, y)
+```

--- a/vassoura/preprocessing/__init__.py
+++ b/vassoura/preprocessing/__init__.py
@@ -2,5 +2,13 @@
 
 from .sampler import SampleManager
 from .scaler import DynamicScaler
-
-__all__ = ["SampleManager", "DynamicScaler"]
+from .encoders import WOEGuard, OneHotLite, OrdinalSafe
+from .pipelines import make_default_pipeline
+__all__ = [
+    "SampleManager",
+    "DynamicScaler",
+    "WOEGuard",
+    "OneHotLite",
+    "OrdinalSafe",
+    "make_default_pipeline",
+]

--- a/vassoura/preprocessing/encoders.py
+++ b/vassoura/preprocessing/encoders.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+"""Encoding utilities for categorical features."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, TransformerMixin
+from sklearn.preprocessing import OneHotEncoder
+
+from vassoura.logs import get_logger
+
+
+class WOEGuard(BaseEstimator, TransformerMixin):
+    """Weight-of-Evidence encoder with safeguards for rare categories."""
+
+    def __init__(
+        self,
+        min_samples: int = 50,
+        apply_smoothing: bool = True,
+        smoothing_alpha: float = 0.5,
+        handle_missing: str = "separate",
+        clip_values: bool = True,
+        verbose: int = 1,
+    ) -> None:
+        self.min_samples = min_samples
+        self.apply_smoothing = apply_smoothing
+        self.smoothing_alpha = smoothing_alpha
+        self.handle_missing = handle_missing
+        self.clip_values = clip_values
+        self.verbose = verbose
+        self.logger = get_logger("WOEGuard")
+        if verbose >= 2:
+            self.logger.setLevel("DEBUG")
+        else:
+            self.logger.setLevel("INFO")
+        self.woe_dict_: dict[str, dict[Any, float]] = {}
+        self.iv_: pd.Series = pd.Series(dtype=float)
+        self.cat_counts_: pd.Series = pd.Series(dtype=int)
+        self.fill_map_: dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    def _prepare_col(self, s: pd.Series, col: str) -> pd.Series:
+        if self.handle_missing == "separate":
+            return s.fillna("__missing__")
+        if self.handle_missing == "most_frequent":
+            mode = s.dropna().mode()
+            fill_val = mode.iloc[0] if not mode.empty else "__missing__"
+            self.fill_map_[col] = fill_val
+            return s.fillna(fill_val)
+        if self.handle_missing == "drop":
+            return s.dropna()
+        raise ValueError(
+            "handle_missing must be 'separate', 'most_frequent' or 'drop'"
+        )
+
+    # ------------------------------------------------------------------
+    def fit(self, X: pd.DataFrame, y: Iterable) -> "WOEGuard":
+        df = pd.DataFrame(X).copy()
+        y_ser = pd.Series(y)
+        uniq = sorted(pd.unique(y_ser.dropna()))
+        if len(uniq) != 2 or set(uniq) != {0, 1}:
+            raise ValueError(
+                "WOEGuard supports binary target with labels {0,1}"
+            )
+        total_good = int((y_ser == 0).sum())
+        total_bad = int((y_ser == 1).sum())
+
+        iv_dict: dict[str, float] = {}
+        cat_count: dict[str, int] = {}
+        merged_total = 0
+
+        for col in df.columns:
+            s = df[col]
+            y_col = y_ser
+            if self.handle_missing == "drop":
+                mask = s.notna()
+                s = s[mask]
+                y_col = y_ser[mask]
+            else:
+                s = self._prepare_col(s, col)
+
+            counts = s.value_counts()
+            rare = counts[counts < self.min_samples].index
+            merged_total += int(counts[counts < self.min_samples].sum())
+            if len(rare) > 0:
+                s = s.where(~s.isin(rare), "__other__")
+            temp = pd.DataFrame({"cat": s, "target": y_col})
+            ctab = pd.crosstab(temp["cat"], temp["target"])
+            if 0 not in ctab.columns:
+                ctab[0] = 0
+            if 1 not in ctab.columns:
+                ctab[1] = 0
+            good = ctab[0].astype(float)
+            bad = ctab[1].astype(float)
+            if self.apply_smoothing:
+                good += self.smoothing_alpha
+                bad += self.smoothing_alpha
+                N_good = total_good + self.smoothing_alpha * len(ctab)
+                N_bad = total_bad + self.smoothing_alpha * len(ctab)
+            else:
+                N_good = total_good
+                N_bad = total_bad
+            if self.clip_values:
+                good = good.clip(lower=1e-6)
+                bad = bad.clip(lower=1e-6)
+            woe = np.log((good / N_good) / (bad / N_bad))
+            iv_vals = ((good / N_good) - (bad / N_bad)) * woe
+            iv = float(iv_vals.sum())
+            mapping = woe.to_dict()
+            self.woe_dict_[col] = mapping
+            iv_dict[col] = iv
+            cat_count[col] = len(mapping)
+            if self.verbose >= 2:
+                self.logger.debug("%s IV=%.4f", col, iv)
+
+        self.iv_ = pd.Series(iv_dict)
+        self.cat_counts_ = pd.Series(cat_count)
+        self.logger.info(
+            "[WOEGuard] fitted %d categorical cols | IV>0.02: %d "
+            "| merged rare cats: %d",
+            len(df.columns),
+            int((self.iv_ > 0.02).sum()),
+            merged_total,
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        df = pd.DataFrame(X).copy()
+        out: dict[str, Any] = {}
+        for col in df.columns:
+            s = df[col]
+            if self.handle_missing == "separate":
+                s = s.fillna("__missing__")
+            elif self.handle_missing == "most_frequent":
+                fill_val = self.fill_map_.get(col, "__missing__")
+                s = s.fillna(fill_val)
+            elif self.handle_missing == "drop":
+                pass  # keep NaNs
+            mapping = self.woe_dict_.get(col, {})
+            default = mapping.get("__other__", 0.0)
+            out[f"woe_{col}"] = (
+                s.map(mapping).fillna(default).astype(np.float32)
+            )
+        return pd.DataFrame(out, index=df.index)
+
+
+class OneHotLite(OneHotEncoder):
+    """Wrapper around :class:`sklearn.preprocessing.OneHotEncoder`."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            handle_unknown="ignore",
+            sparse_output=False,
+            min_frequency=0.01,
+            **kwargs,
+        )
+
+
+class OrdinalSafe(BaseEstimator, TransformerMixin):
+    """Frequency-based ordinal encoder for tree models."""
+
+    def __init__(self, verbose: int = 0) -> None:
+        self.verbose = verbose
+        self.logger = get_logger("OrdinalSafe")
+        if verbose >= 2:
+            self.logger.setLevel("DEBUG")
+        else:
+            self.logger.setLevel("INFO")
+        self.mapping_: dict[str, dict[Any, int]] = {}
+
+    def fit(self, X: pd.DataFrame, y: Any = None) -> "OrdinalSafe":
+        df = pd.DataFrame(X)
+        for col in df.columns:
+            counts = df[col].value_counts()
+            mapping = {cat: i for i, cat in enumerate(counts.index)}
+            self.mapping_[col] = mapping
+            if self.verbose >= 2:
+                self.logger.debug("%s categories=%d", col, len(mapping))
+        return self
+
+    def transform(self, X: pd.DataFrame) -> pd.DataFrame:
+        df = pd.DataFrame(X)
+        out: dict[str, Any] = {}
+        for col in df.columns:
+            mapping = self.mapping_.get(col, {})
+            default = len(mapping)
+            out[col] = df[col].map(mapping).fillna(default).astype(np.int32)
+        return pd.DataFrame(out, index=df.index)
+
+
+__all__ = ["WOEGuard", "OneHotLite", "OrdinalSafe"]

--- a/vassoura/preprocessing/pipelines.py
+++ b/vassoura/preprocessing/pipelines.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import numpy as np
+from sklearn.base import BaseEstimator
+from sklearn.compose import ColumnTransformer, make_column_selector
+from sklearn.pipeline import Pipeline
+
+from .scaler import DynamicScaler
+from .encoders import WOEGuard, OneHotLite, OrdinalSafe
+
+
+def make_default_pipeline(
+    num_cols: List[str] | None = None,
+    cat_cols: List[str] | None = None,
+    *,
+    scaler_strategy: str = "auto",
+    encoder: str = "woe",
+    sampler: BaseEstimator | None = None,
+) -> Pipeline:
+    """Return a pre-configured preprocessing pipeline."""
+
+    if num_cols is None:
+        num_sel: Any = make_column_selector(dtype_include=np.number)
+    else:
+        num_sel = num_cols
+
+    if cat_cols is None:
+        cat_sel: Any = make_column_selector(dtype_exclude=np.number)
+    else:
+        cat_sel = cat_cols
+
+    num_pipe = Pipeline([
+        ("scaler", DynamicScaler(strategy=scaler_strategy)),
+    ])
+
+    if encoder == "woe":
+        cat_encoder: Any = WOEGuard()
+    elif encoder == "onehot":
+        cat_encoder = OneHotLite()
+    elif encoder == "ordinal":
+        cat_encoder = OrdinalSafe()
+    elif encoder == "none":
+        cat_encoder = "drop"
+    else:
+        raise ValueError(f"Unknown encoder '{encoder}'")
+
+    transformers = [
+        ("num", num_pipe, num_sel),
+        ("cat", cat_encoder, cat_sel),
+    ]
+
+    ct = ColumnTransformer(transformers, remainder="drop")
+
+    steps: list[tuple[str, Any]] = []
+    if sampler is not None:
+        steps.append(("sampler", sampler))
+    steps.append(("ct", ct))
+
+    return Pipeline(steps)

--- a/vassoura/preprocessing/sampler.py
+++ b/vassoura/preprocessing/sampler.py
@@ -129,16 +129,20 @@ class SampleManager(BaseEstimator, TransformerMixin):
 
     def transform(
         self, X: pd.DataFrame, y: Iterable | None = None
-    ) -> pd.DataFrame | tuple[pd.DataFrame, Iterable]:
-        X_res, y_res = self._apply_sampling(X, y)
-        if y is not None:
-            return X_res, y_res
+    ) -> pd.DataFrame:
+        X_res, _ = self._apply_sampling(X, y)
         return X_res
+
+    def fit_transform(
+        self, X: pd.DataFrame, y: Iterable | None = None
+    ) -> pd.DataFrame:
+        return self.fit(X, y).transform(X, y)
 
     def fit_resample(
         self, X: pd.DataFrame, y: Iterable
     ) -> tuple[pd.DataFrame, Iterable]:
-        return self.fit(X, y).transform(X, y)
+        self.fit(X, y)
+        return self._apply_sampling(X, y)
 
     def get_support_mask(self) -> np.ndarray:
         if self.mask_.size == 0:

--- a/vassoura/preprocessing/scaler.py
+++ b/vassoura/preprocessing/scaler.py
@@ -32,7 +32,7 @@ class DynamicScaler(BaseEstimator, TransformerMixin):
     ) -> None:
         self.strategy = strategy
         self.preferred = preferred
-        self.exclude_cols = exclude_cols or []
+        self.exclude_cols = exclude_cols if exclude_cols is not None else []
         self.n_quantiles = n_quantiles
         self.output_distribution = output_distribution
         self.verbose = verbose

--- a/vassoura/tests/test_encoders_pipeline.py
+++ b/vassoura/tests/test_encoders_pipeline.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from vassoura.preprocessing import (
+    WOEGuard,
+    OneHotLite,
+    SampleManager,
+    make_default_pipeline,
+)
+
+
+def _make_df() -> tuple[pd.DataFrame, pd.Series]:
+    cat = ["a"] * 50 + ["b"] * 50 + ["c"] * 50 + ["d"] * 50
+    y = (
+        [0] * 45
+        + [1] * 5
+        + [0] * 40
+        + [1] * 10
+        + [0] * 35
+        + [1] * 15
+        + [0] * 30
+        + [1] * 20
+    )
+    df = pd.DataFrame({"cat": cat, "num": range(200)})
+    return df, pd.Series(y)
+
+
+def test_woe_values_monotonic():
+    X, y = _make_df()
+    enc = WOEGuard(min_samples=1)
+    enc.fit(X[["cat"]], y)
+    mapping = enc.woe_dict_["cat"]
+    woe_vals = [mapping[v] for v in ["a", "b", "c", "d"]]
+    assert all(x > y for x, y in zip(woe_vals[:-1], woe_vals[1:]))
+
+
+def test_iv_positive():
+    X, y = _make_df()
+    enc = WOEGuard(min_samples=1)
+    enc.fit(X[["cat"]], y)
+    assert (enc.iv_ >= 0).all()
+
+
+def test_make_default_pipeline_shapes():
+    X, y = _make_df()
+    pipe = make_default_pipeline(num_cols=["num"], cat_cols=["cat"])
+    Xt = pipe.fit_transform(X, y)
+    assert Xt.shape[0] == len(X)
+
+
+def test_inference_auto_cols():
+    X, y = _make_df()
+    pipe = make_default_pipeline()
+    Xt = pipe.fit_transform(X, y)
+    assert Xt.shape[0] == len(X)
+
+
+def test_encoder_switching():
+    X, y = _make_df()
+    pipe = make_default_pipeline(
+        num_cols=["num"], cat_cols=["cat"], encoder="onehot"
+    )
+    pipe.fit(X, y)
+    ct = pipe.named_steps["ct"]
+    assert isinstance(ct.named_transformers_["cat"], OneHotLite)
+
+
+def test_sampler_integration():
+    X, y = _make_df()
+    sm = SampleManager(strategy="stratified", frac=0.5, random_state=0)
+    pipe = make_default_pipeline(
+        num_cols=["num"], cat_cols=["cat"], sampler=sm
+    )
+    Xt = pipe.fit_transform(X, y)
+    assert Xt.shape[0] == sm.sample_size_
+
+
+def test_logging_encoder_counts(caplog):
+    X, y = _make_df()
+    enc = WOEGuard(min_samples=1, verbose=1)
+    with caplog.at_level("INFO"):
+        enc.fit(X[["cat"]], y)
+    msgs = [rec.message for rec in caplog.records]
+    assert any("fitted" in m for m in msgs)


### PR DESCRIPTION
## Summary
- implement `WOEGuard`, `OneHotLite`, and `OrdinalSafe` encoders
- add `make_default_pipeline` factory
- integrate new utilities in preprocessing package
- update SampleManager for pipeline usage
- document quick modelling example
- include new unit tests for encoders and pipeline

## Testing
- `flake8 vassoura/preprocessing/encoders.py vassoura/preprocessing/pipelines.py vassoura/tests/test_encoders_pipeline.py vassoura/preprocessing/scaler.py vassoura/preprocessing/sampler.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f2a9a3588321adbb76110776675f