### PR TITLE
Add CV utilities and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ model = Pipeline([
 ])
 model.fit(X, y)
 ```
+
+### Cross-validation
+
+```python
+from vassoura.validation import get_stratified_cv
+from vassoura.utils.metrics import SCORERS
+
+cv = get_stratified_cv(5)
+scores = cross_validate(pipe, X, y, cv=cv, scoring=SCORERS)
+```

--- a/vassoura/tests/test_metrics.py
+++ b/vassoura/tests/test_metrics.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from vassoura.utils.metrics import (
+    roc_auc_score_safe,
+    brier_score,
+    ks_statistic,
+    classification_report_df,
+    SCORERS,
+)
+
+
+def test_auc_safe_single_class():
+    y = pd.Series([1, 1, 1])
+    pred = pd.Series([0.2, 0.3, 0.4])
+    assert roc_auc_score_safe(y, pred) == 0.5
+
+
+def test_brier_bounds():
+    y = pd.Series([0, 1, 0, 1])
+    p = pd.Series([0.1, 0.8, 0.2, 0.7])
+    val = brier_score(y, p)
+    assert 0 <= val <= 1
+
+
+def test_ks_statistic_range():
+    y = pd.Series([0, 0, 1, 1])
+    p = pd.Series([0.1, 0.2, 0.8, 0.7])
+    ks = ks_statistic(y, p)
+    assert 0 <= ks <= 1
+
+
+def test_classification_report_df_shape():
+    y_true = pd.Series([0, 0, 1, 1])
+    y_pred = pd.Series([0, 1, 1, 1])
+    df = classification_report_df(y_true, y_pred)
+    for col in ["precision", "recall", "f1-score", "support"]:
+        assert col in df.columns
+
+
+def test_scorers_dict_completeness():
+    assert set(SCORERS.keys()) == {"auc", "pr_auc", "f1", "mcc", "brier", "ks"}

--- a/vassoura/tests/test_validation.py
+++ b/vassoura/tests/test_validation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from vassoura.validation import get_stratified_cv, get_time_series_cv
+from vassoura.validation.cv import train_test_split_by_date
+
+
+def test_stratified_cv_preserves_ratio():
+    X = pd.DataFrame({"a": range(200)})
+    y = pd.Series([0] * 150 + [1] * 50)
+    cv = get_stratified_cv(n_splits=4, shuffle=True, random_state=0)
+    overall = y.mean()
+    for train_idx, test_idx in cv.split(X, y):
+        train_ratio = y.iloc[train_idx].mean()
+        test_ratio = y.iloc[test_idx].mean()
+        assert abs(train_ratio - overall) <= 0.01 + 1e-8
+        assert abs(test_ratio - overall) <= 0.01 + 1e-8
+
+
+def test_time_series_gap_enforced():
+    X = pd.DataFrame({"val": range(20)})
+    cv = get_time_series_cv(n_splits=4, gap=2)
+    for train_idx, test_idx in cv.split(X):
+        assert train_idx.max() + 2 < test_idx.min()
+
+
+def test_split_by_date():
+    dates = pd.date_range("2022-01-01", periods=10)
+    df = pd.DataFrame({"ts": dates, "val": range(10)})
+    train, test = train_test_split_by_date(df, "ts", "2022-01-05")
+    assert train["ts"].max() <= pd.Timestamp("2022-01-05")
+    assert test["ts"].min() > pd.Timestamp("2022-01-05")

--- a/vassoura/utils/__init__.py
+++ b/vassoura/utils/__init__.py
@@ -1,1 +1,5 @@
-"""Sub-package stub."""
+"""Utility functions for modelling."""
+
+from .metrics import SCORERS
+
+__all__ = ["SCORERS"]

--- a/vassoura/utils/metrics.py
+++ b/vassoura/utils/metrics.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import pandas as pd
+from sklearn.metrics import (
+    roc_auc_score,
+    average_precision_score,
+    f1_score,
+    matthews_corrcoef,
+    brier_score_loss,
+    classification_report,
+    make_scorer,
+)
+from scipy.stats import ks_2samp
+
+
+__all__ = [
+    "roc_auc_score_safe",
+    "pr_auc_score_safe",
+    "f1_safe",
+    "mcc_safe",
+    "brier_score",
+    "ks_statistic",
+    "classification_report_df",
+    "SCORERS",
+]
+
+
+def roc_auc_score_safe(y_true, y_pred) -> float:
+    try:
+        score = roc_auc_score(y_true, y_pred)
+        if pd.isna(score):
+            return 0.5
+        return score
+    except ValueError:
+        return 0.5
+
+
+def pr_auc_score_safe(y_true, y_pred) -> float:
+    return average_precision_score(y_true, y_pred)
+
+
+def f1_safe(y_true, y_pred) -> float:
+    return f1_score(y_true, y_pred, zero_division=0)
+
+
+def mcc_safe(y_true, y_pred) -> float:
+    return matthews_corrcoef(y_true, y_pred)
+
+
+def brier_score(y_true, y_prob) -> float:
+    return brier_score_loss(y_true, y_prob)
+
+
+def ks_statistic(y_true, y_prob) -> float:
+    pos_scores = y_prob[y_true == 1]
+    neg_scores = y_prob[y_true == 0]
+    if len(pos_scores) == 0 or len(neg_scores) == 0:
+        return 0.0
+    return ks_2samp(pos_scores, neg_scores).statistic
+
+
+def classification_report_df(y_true, y_pred) -> pd.DataFrame:
+    rep = classification_report(y_true, y_pred, output_dict=True)
+    return pd.DataFrame(rep).T
+
+
+SCORERS = {
+    "auc": make_scorer(roc_auc_score_safe, needs_proba=True),
+    "pr_auc": make_scorer(pr_auc_score_safe, needs_proba=True),
+    "f1": make_scorer(f1_safe),
+    "mcc": make_scorer(mcc_safe),
+    "brier": make_scorer(
+        brier_score, needs_proba=True, greater_is_better=False
+    ),
+    "ks": make_scorer(ks_statistic, needs_proba=True),
+}

--- a/vassoura/validation/__init__.py
+++ b/vassoura/validation/__init__.py
@@ -1,1 +1,5 @@
-"""Sub-package stub."""
+"""Cross-validation utilities."""
+
+from .cv import get_stratified_cv, get_time_series_cv
+
+__all__ = ["get_stratified_cv", "get_time_series_cv"]

--- a/vassoura/validation/cv.py
+++ b/vassoura/validation/cv.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pandas as pd
+from sklearn.model_selection import KFold, StratifiedKFold, TimeSeriesSplit
+from sklearn.utils.multiclass import type_of_target
+
+from vassoura.logs import get_logger
+
+
+logger = get_logger("validation")
+
+
+class _StratifiedWrapper:
+    """Choose StratifiedKFold or KFold based on target type."""
+
+    def __init__(
+        self, n_splits: int, shuffle: bool, random_state: int | None
+    ) -> None:
+        self.n_splits = n_splits
+        self.shuffle = shuffle
+        self.random_state = random_state
+        self._skf = StratifiedKFold(
+            n_splits=n_splits, shuffle=shuffle, random_state=random_state
+        )
+        self._kf = KFold(
+            n_splits=n_splits, shuffle=shuffle, random_state=random_state
+        )
+        self.name = "StratifiedKFold(%d)" % n_splits
+
+    def split(self, X, y=None, groups=None):
+        if y is not None:
+            try:
+                target_type = type_of_target(y)
+            except Exception:
+                target_type = "unknown"
+            if target_type in {"binary", "multiclass"}:
+                return self._skf.split(X, y, groups)
+        self.name = "KFold(%d)" % self.n_splits
+        return self._kf.split(X, y, groups)
+
+    def get_n_splits(self, X=None, y=None, groups=None):
+        return self.n_splits
+
+
+def get_stratified_cv(
+    n_splits: int = 5, shuffle: bool = True, random_state: int | None = 42
+):
+    """Return a CV object that stratifies when appropriate."""
+    cv = _StratifiedWrapper(n_splits, shuffle, random_state)
+    logger.info(
+        "[CV] Using %s(n_splits=%d, shuffle=%s)",
+        "StratifiedKFold",
+        n_splits,
+        shuffle,
+    )
+    return cv
+
+
+class _TimeSeriesWrapper(TimeSeriesSplit):
+    def split(self, X, y=None, groups=None):  # type: ignore[override]
+        for train_idx, test_idx in super().split(X, y, groups):
+            if train_idx.size and test_idx.size:
+                if train_idx.max() + self.gap >= test_idx.min():
+                    raise ValueError("Gap leads to data leakage")
+            yield train_idx, test_idx
+
+
+def get_time_series_cv(
+    n_splits: int = 5, test_size: int | None = None, gap: int = 0
+):
+    if gap < 0:
+        raise ValueError("gap must be >= 0")
+    cv = _TimeSeriesWrapper(n_splits=n_splits, test_size=test_size, gap=gap)
+    cv.name = f"TimeSeriesSplit({n_splits})"
+    logger.info(
+        "[CV] Using TimeSeriesSplit(n_splits=%d, gap=%d)",
+        n_splits,
+        gap,
+    )
+    return cv
+
+
+def train_test_split_by_date(
+    df: pd.DataFrame, time_col: str, split_date: str | pd.Timestamp
+):
+    if time_col not in df.columns:
+        raise ValueError(f"{time_col} not in DataFrame")
+    ts = pd.to_datetime(split_date)
+    train = df[df[time_col] <= ts]
+    test = df[df[time_col] > ts]
+    return train, test


### PR DESCRIPTION
## Summary
- add cross-validation helpers and train/test split by date
- implement safe classification metrics and SCORERS dict
- expose new API via `__init__` modules
- document CV usage in README
- add tests for new helpers and metrics

## Testing
- `flake8 vassoura/validation/*.py vassoura/utils/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848f58316548321999316c41770b3aa