### PR TITLE
Add model wrappers registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,19 @@ from vassoura.utils.metrics import SCORERS
 cv = get_stratified_cv(5)
 scores = cross_validate(pipe, X, y, cv=cv, scoring=SCORERS)
 ```
+
+## Model Zoo
+
+Ready-to-use wrappers are available via `vassoura.models` registry:
+
+```python
+from vassoura.models import get, list_models
+
+print(list_models())  # ['logistic_balanced', ...]
+Model = get('logistic_balanced')
+model = Model()
+model.fit(X_train, y_train)
+```
+
+All wrappers automatically handle class imbalance using `sample_weight` when
+supported by the underlying library.

--- a/vassoura/__init__.py
+++ b/vassoura/__init__.py
@@ -1,3 +1,6 @@
 """Vassoura – Unified feature-selection & reporting framework."""
-__all__ = []   # will be extended in later tasks
+
+from .models import get as get_model, list_models
+
+__all__ = ["get_model", "list_models"]
 __version__ = "0.0.1a0"

--- a/vassoura/logs.py
+++ b/vassoura/logs.py
@@ -1,7 +1,10 @@
-import logging, sys
+import logging
+import sys
 
 
-def get_logger(name: str = "vassoura", level: int = logging.INFO) -> logging.Logger:
+def get_logger(
+    name: str = "vassoura", level: int = logging.INFO
+) -> logging.Logger:
     logger = logging.getLogger(name)
     if not logger.handlers:
         handler = logging.StreamHandler(sys.stdout)

--- a/vassoura/models/__init__.py
+++ b/vassoura/models/__init__.py
@@ -1,1 +1,5 @@
-"""Sub-package stub."""
+"""Model wrappers and registry."""
+
+from .registry import get, list_models
+
+__all__ = ["get", "list_models"]

--- a/vassoura/models/base.py
+++ b/vassoura/models/base.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Mapping
+
+
+class WrapperBase(ABC):
+    """Abstract base class for model wrappers."""
+
+    name: str
+    model: Any
+
+    @abstractmethod
+    def __init__(self, **params) -> None:  # pragma: no cover - interface only
+        ...
+
+    @abstractmethod
+    def fit(
+        self, X, y, sample_weight=None
+    ):  # pragma: no cover - interface only
+        ...
+
+    @abstractmethod
+    def predict(self, X):  # pragma: no cover - interface only
+        ...
+
+    def get_params(self, deep: bool = True) -> Mapping[str, Any]:
+        if hasattr(self.model, "get_params"):
+            return self.model.get_params(deep=deep)
+        return {}
+
+    def set_params(self, **params):
+        if hasattr(self.model, "set_params"):
+            self.model.set_params(**params)
+        return self

--- a/vassoura/models/lgb.py
+++ b/vassoura/models/lgb.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import lightgbm as lgb
+
+from vassoura.logs import get_logger
+
+from .base import WrapperBase
+from .utils import make_sample_weights, supports_sample_weight
+
+
+class LightGBMWrapper(WrapperBase):
+    """LightGBM classifier wrapper with balanced weights."""
+
+    name = "lightgbm_balanced"
+
+    def __init__(self, **params) -> None:
+        defaults = dict(
+            objective="binary",
+            learning_rate=0.05,
+            n_estimators=400,
+            max_depth=-1,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            n_jobs=-1,
+        )
+        defaults.update(params)
+        self.model = lgb.LGBMClassifier(**defaults)
+        self.logger = get_logger("ModelWrapper")
+
+    def fit(self, X, y, sample_weight=None):
+        if sample_weight is None:
+            sample_weight = make_sample_weights(y)
+        sw_used = supports_sample_weight(self.model)
+        if sw_used:
+            self.model.fit(X, y, sample_weight=sample_weight)
+        else:
+            if "is_unbalance" in self.model.get_params():
+                self.model.set_params(is_unbalance=True)
+            self.model.fit(X, y)
+        self.logger.debug(
+            "[ModelWrapper] model='%s' | params=%d | sample_weight=%s",
+            self.name,
+            len(self.get_params()),
+            "used" if sw_used else "fallback",
+        )
+        return self
+
+    def predict(self, X):
+        return self.model.predict_proba(X)[:, 1]

--- a/vassoura/models/lr.py
+++ b/vassoura/models/lr.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from sklearn.linear_model import LogisticRegression
+
+from vassoura.logs import get_logger
+
+from .base import WrapperBase
+from .utils import make_sample_weights, supports_sample_weight
+
+
+class LogisticRegressionWrapper(WrapperBase):
+    """Logistic Regression with balanced sampling."""
+
+    name = "logistic_balanced"
+
+    def __init__(self, **params) -> None:
+        defaults = dict(
+            penalty="l2",
+            C=1.0,
+            solver="lbfgs",
+            max_iter=400,
+            n_jobs=-1,
+        )
+        defaults.update(params)
+        self.model = LogisticRegression(**defaults)
+        self.logger = get_logger("ModelWrapper")
+
+    def fit(self, X, y, sample_weight=None):
+        if sample_weight is None:
+            sample_weight = make_sample_weights(y)
+        sw_used = supports_sample_weight(self.model)
+        if sw_used:
+            self.model.fit(X, y, sample_weight=sample_weight)
+        else:
+            if "class_weight" in self.model.get_params():
+                self.model.set_params(class_weight="balanced")
+            self.model.fit(X, y)
+        self.logger.debug(
+            "[ModelWrapper] model='%s' | params=%d | sample_weight=%s",
+            self.name,
+            len(self.get_params()),
+            "used" if sw_used else "fallback",
+        )
+        return self
+
+    def predict(self, X):
+        return self.model.predict_proba(X)[:, 1]

--- a/vassoura/models/registry.py
+++ b/vassoura/models/registry.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+import pkgutil
+
+from .base import WrapperBase
+
+_registry: dict[str, type] = {}
+
+
+def _discover() -> None:
+    pkg = Path(__file__).parent
+    for _, name, _ in pkgutil.iter_modules([str(pkg)]):
+        if name in {"__init__", "base", "registry", "utils"}:
+            continue
+        module = import_module(f"vassoura.models.{name}")
+        for attr in dir(module):
+            obj = getattr(module, attr)
+            if (
+                isinstance(obj, type)
+                and hasattr(obj, "name")
+                and issubclass(obj, WrapperBase)
+            ):
+                _registry[obj.name] = obj
+
+
+def get(name: str):
+    return _registry[name]
+
+
+def list_models() -> list[str]:
+    return list(_registry.keys())
+
+
+_discover()

--- a/vassoura/models/utils.py
+++ b/vassoura/models/utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import numpy as np
+from inspect import signature
+from sklearn.utils.class_weight import compute_sample_weight
+
+
+def make_sample_weights(y) -> np.ndarray:
+    """Return array of weights using 'balanced' strategy."""
+    return compute_sample_weight(class_weight="balanced", y=y)
+
+
+def supports_sample_weight(estimator) -> bool:
+    """Return True if the estimator.fit accepts sample_weight."""
+    try:
+        sig = signature(estimator.fit)
+    except (AttributeError, ValueError):
+        return False
+    return "sample_weight" in sig.parameters

--- a/vassoura/models/xgb.py
+++ b/vassoura/models/xgb.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import xgboost as xgb
+
+from vassoura.logs import get_logger
+
+from .base import WrapperBase
+from .utils import make_sample_weights, supports_sample_weight
+
+
+class XGBoostWrapper(WrapperBase):
+    """XGBoost classifier wrapper with balanced weights."""
+
+    name = "xgboost_balanced"
+
+    def __init__(self, **params) -> None:
+        defaults = dict(
+            objective="binary:logistic",
+            eval_metric="logloss",
+            learning_rate=0.05,
+            n_estimators=400,
+            max_depth=6,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            n_jobs=-1,
+        )
+        defaults.update(params)
+        self.model = xgb.XGBClassifier(**defaults)
+        self.logger = get_logger("ModelWrapper")
+
+    def fit(self, X, y, sample_weight=None):
+        if sample_weight is None:
+            sample_weight = make_sample_weights(y)
+        sw_used = supports_sample_weight(self.model)
+        if sw_used:
+            self.model.fit(X, y, sample_weight=sample_weight)
+        else:
+            if "class_weight" in self.model.get_params():
+                self.model.set_params(class_weight="balanced")
+            self.model.fit(X, y)
+        self.logger.debug(
+            "[ModelWrapper] model='%s' | params=%d | sample_weight=%s",
+            self.name,
+            len(self.get_params()),
+            "used" if sw_used else "fallback",
+        )
+        return self
+
+    def predict(self, X):
+        return self.model.predict_proba(X)[:, 1]

--- a/vassoura/tests/test_models.py
+++ b/vassoura/tests/test_models.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sklearn.linear_model import LogisticRegression
+
+from vassoura.models import get, list_models
+
+
+@pytest.mark.parametrize("name", list_models())
+def test_wrapper_fit_predict(name):
+    Model = get(name)
+    if "xgboost" in name:
+        pytest.importorskip("xgboost")
+    if "lightgbm" in name:
+        pytest.importorskip("lightgbm")
+    X = pd.DataFrame({"a": [0, 1, 2, 3, 4, 5], "b": [1, 0, 1, 0, 1, 0]})
+    y = pd.Series([0, 1, 0, 1, 0, 1])
+    model = Model()
+    model.fit(X, y)
+    preds = model.predict(X)
+    assert isinstance(preds, np.ndarray) or isinstance(preds, pd.Series)
+    assert len(preds) == len(X)
+
+
+def test_sample_weight_priority():
+    Model = get("logistic_balanced")
+    X = pd.DataFrame({"a": [0, 1, 2, 3], "b": [1, 0, 1, 0]})
+    y = pd.Series([0, 0, 0, 1])
+    called = {}
+    orig_fit = LogisticRegression.fit
+
+    def spy(self, X, y, sample_weight=None):
+        called["sw"] = sample_weight
+        return orig_fit(self, X, y, sample_weight=sample_weight)
+
+    with pytest.MonkeyPatch.context() as mpatch:
+        mpatch.setattr(LogisticRegression, "fit", spy, raising=False)
+        m = Model()
+        m.fit(X, y, sample_weight=None)
+
+    assert called["sw"] is not None
+    assert not np.allclose(called["sw"], 1.0)
+
+
+def test_class_weight_fallback(monkeypatch):
+    class Dummy:
+        def __init__(self, **kw):
+            self.params = kw
+
+        def get_params(self, deep=True):
+            return self.params
+
+        def set_params(self, **kw):
+            self.params.update(kw)
+
+        def fit(self, X, y):
+            self.fitted = True
+    from vassoura.models.lr import LogisticRegressionWrapper
+
+    wrapper = LogisticRegressionWrapper()
+    dummy = Dummy(class_weight=None)
+    wrapper.model = dummy
+    wrapper.fit(pd.DataFrame({"a": [0, 1]}), pd.Series([0, 1]))
+    assert dummy.params["class_weight"] == "balanced"
+
+
+def test_registry_lookup():
+    Model = get("logistic_balanced")
+    from vassoura.models.lr import LogisticRegressionWrapper
+
+    assert Model is LogisticRegressionWrapper

--- a/vassoura/tests/test_validation.py
+++ b/vassoura/tests/test_validation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pandas as pd
-import numpy as np
 
 from vassoura.validation import get_stratified_cv, get_time_series_cv
 from vassoura.validation.cv import train_test_split_by_date


### PR DESCRIPTION
## Summary
- implement `WrapperBase` and sample weight utilities
- add logistic, XGBoost and LightGBM wrappers with automatic weighting
- provide auto-discovery registry
- expose registry in package init
- update README with Model Zoo section
- add comprehensive tests for wrappers

## Testing
- `flake8 vassoura`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848fabd822c8321ae358a95e4da5273