### PR TITLE
Add importance heuristics and weights utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,12 @@ model.fit(X_train, y_train)
 
 All wrappers automatically handle class imbalance using `sample_weight` when
 supported by the underlying library.
+
+## Importance heuristics
+
+```python
+from vassoura.process import basic_importance
+
+imp = basic_importance(X_train, y_train, model="logistic", method="coef")
+print(imp.head())
+```

--- a/vassoura/process/__init__.py
+++ b/vassoura/process/__init__.py
@@ -1,1 +1,11 @@
-"""Sub-package stub."""
+"""Importance heuristics."""
+
+from .basic import basic_importance
+from .medium import medium_importance
+from .advanced import advanced_importance
+
+__all__ = [
+    "basic_importance",
+    "medium_importance",
+    "advanced_importance",
+]

--- a/vassoura/process/advanced.py
+++ b/vassoura/process/advanced.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from .heuristic_boruta_multi_shap import boruta_multi_shap
+
+
+def advanced_importance(
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    n_trials: int = 3,
+    top_k: int | None = None,
+    sample_weight: np.ndarray | None = None,
+    random_state: int | None = 42,
+) -> pd.Series:
+    """Heavy-duty multi-run SHAP importance.
+
+    Parameters
+    ----------
+    X : pandas.DataFrame
+        Feature matrix.
+    y : pandas.Series
+        Target vector.
+    n_trials : int, default 3
+        Number of repetitions.
+    top_k : int | None, optional
+        Return only top k features.
+    sample_weight : numpy.ndarray | None, optional
+        Sample weights.
+    random_state : int | None, optional
+        Random seed.
+    """
+    return boruta_multi_shap(
+        X,
+        y,
+        n_trials=n_trials,
+        top_k=top_k,
+        sample_weight=sample_weight,
+        random_state=random_state,
+    )

--- a/vassoura/process/basic.py
+++ b/vassoura/process/basic.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+from vassoura.logs import get_logger
+from vassoura.models.utils import supports_sample_weight
+from vassoura.utils.weights import make_balanced_sample_weights
+
+logger = get_logger(__name__)
+
+
+def _make_model(name: str, random_state: int | None):
+    if name == "logistic":
+        from sklearn.linear_model import LogisticRegression
+
+        return LogisticRegression(max_iter=200, n_jobs=-1, random_state=random_state)
+    if name == "lgb":
+        import lightgbm as lgb
+
+        return lgb.LGBMClassifier(
+            n_estimators=200,
+            max_depth=5,
+            learning_rate=0.1,
+            random_state=random_state,
+            n_jobs=-1,
+            verbosity=-1,
+        )
+    if name == "xgb":
+        import xgboost as xgb
+
+        return xgb.XGBClassifier(
+            n_estimators=200,
+            max_depth=5,
+            learning_rate=0.1,
+            subsample=0.8,
+            colsample_bytree=0.8,
+            eval_metric="logloss",
+            random_state=random_state,
+            n_jobs=-1,
+        )
+    raise ValueError(f"unknown model '{name}'")
+
+
+def basic_importance(
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    model: str = "logistic",
+    method: str = "coef",
+    top_k: int | None = None,
+    sample_weight: np.ndarray | None = None,
+    random_state: int | None = 42,
+) -> pd.Series:
+    """Quick feature importance using a lightweight model.
+
+    Parameters
+    ----------
+    X : pandas.DataFrame
+        Feature matrix.
+    y : pandas.Series
+        Target vector.
+    model : {{"logistic", "lgb", "xgb"}}, default "logistic"
+        Base model to fit.
+    method : {{"coef", "gain", "shap"}}, default "coef"
+        Importance type.
+    top_k : int | None, optional
+        Return only the top k features.
+    sample_weight : numpy.ndarray | None, optional
+        Sample weights array.
+    random_state : int | None, optional
+        Random seed.
+
+    Returns
+    -------
+    pandas.Series
+        Importance ordered by absolute value.
+    """
+    if sample_weight is None:
+        sample_weight = make_balanced_sample_weights(y)
+
+    if method == "coef" and model in {"lgb", "xgb"}:
+        method = "gain"
+
+    rng = np.random.default_rng(random_state)
+    Xw = X.copy()
+    Xw["__noise_uniform__"] = rng.uniform(0, 1, size=len(Xw))
+
+    est = _make_model(model, random_state)
+    if supports_sample_weight(est):
+        est.fit(Xw, y, sample_weight=sample_weight)
+    else:
+        if hasattr(est, "get_params") and "class_weight" in est.get_params():
+            est.set_params(class_weight="balanced")
+        est.fit(Xw, y)
+
+    if method in {"coef", "gain"}:
+        if model == "logistic":
+            coef = getattr(est, "coef_", np.zeros(Xw.shape[1]))
+            imp = pd.Series(coef.ravel(), index=Xw.columns)
+        elif model == "lgb":
+            booster = est.booster_
+            vals = booster.feature_importance(importance_type="gain")
+            imp = pd.Series(vals, index=est.feature_name_)
+        else:
+            booster = est.get_booster()
+            score = booster.get_score(importance_type="gain")
+            imp = pd.Series({k: v for k, v in score.items()})
+            imp = imp.reindex(Xw.columns, fill_value=0)
+    elif method == "shap":
+        import shap
+
+        if model == "logistic":
+            masker = shap.maskers.Independent(Xw)
+            expl = shap.LinearExplainer(est, masker=masker)
+        else:
+            expl = shap.TreeExplainer(est)
+        sv = expl.shap_values(Xw)
+        if isinstance(sv, list):
+            sv = np.stack(sv).sum(axis=0)
+        imp = pd.Series(np.abs(sv).mean(axis=0), index=Xw.columns)
+    else:
+        raise ValueError("method must be 'coef', 'gain' or 'shap'")
+
+    imp = imp.reindex(Xw.columns).fillna(0)
+    imp = imp.reindex(Xw.columns)
+    imp = imp.abs().sort_values(ascending=False)
+    if top_k is not None:
+        imp = imp.iloc[:top_k]
+    return imp

--- a/vassoura/process/heuristic_boruta_multi_shap.py
+++ b/vassoura/process/heuristic_boruta_multi_shap.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import shap
+from sklearn.ensemble import RandomForestClassifier
+
+from vassoura.logs import get_logger
+from vassoura.models.utils import supports_sample_weight
+from vassoura.utils.weights import make_balanced_sample_weights
+
+logger = get_logger(__name__)
+
+
+def boruta_multi_shap(
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    n_trials: int = 3,
+    top_k: int | None = None,
+    sample_weight: np.ndarray | None = None,
+    random_state: int | None = None,
+) -> pd.Series:
+    """Compute repeated SHAP importances using RandomForest.
+
+    Parameters
+    ----------
+    X : pandas.DataFrame
+        Feature matrix.
+    y : pandas.Series
+        Target vector.
+    n_trials : int, default 3
+        Number of repetitions.
+    top_k : int | None, optional
+        Return only top k features.
+    sample_weight : numpy.ndarray | None, optional
+        Sample weights.
+    random_state : int | None, optional
+        Random seed.
+    """
+    if sample_weight is None:
+        sample_weight = make_balanced_sample_weights(y)
+
+    rng = np.random.default_rng(random_state)
+    Xw = X.copy()
+    Xw["__noise_uniform__"] = rng.uniform(0, 1, size=len(Xw))
+
+    importances = pd.Series(0.0, index=Xw.columns)
+
+    for i in range(n_trials):
+        est = RandomForestClassifier(
+            n_estimators=100,
+            max_depth=5,
+            random_state=rng.integers(0, 1_000_000),
+            n_jobs=-1,
+        )
+        if supports_sample_weight(est):
+            est.fit(Xw, y, sample_weight=sample_weight)
+        else:
+            est.fit(Xw, y)
+
+        expl = shap.TreeExplainer(est)
+        sv = expl.shap_values(Xw)
+        if isinstance(sv, list):
+            sv = np.stack(sv, axis=-1)
+        if sv.ndim == 3:
+            sv = sv.sum(axis=-1)
+        vals = np.abs(sv).mean(axis=0)
+        importances = importances.add(pd.Series(vals, index=Xw.columns), fill_value=0)
+        logger.info(
+            "[Advanced] trial %d/%d finished – kept=%d features", i + 1, n_trials, len(Xw.columns)
+        )
+
+    importances /= n_trials
+    importances = importances.abs().sort_values(ascending=False)
+    if top_k is not None:
+        importances = importances.iloc[:top_k]
+    return importances

--- a/vassoura/process/medium.py
+++ b/vassoura/process/medium.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.base import clone
+from sklearn.inspection import permutation_importance
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score, make_scorer
+from sklearn.model_selection import StratifiedKFold
+
+from vassoura.models.utils import supports_sample_weight
+from vassoura.utils.weights import make_balanced_sample_weights
+
+
+def medium_importance(
+    X: pd.DataFrame,
+    y: pd.Series,
+    *,
+    cv_splits: int = 5,
+    n_repeats: int = 5,
+    top_k: int | None = None,
+    sample_weight: np.ndarray | None = None,
+    random_state: int | None = 42,
+) -> pd.Series:
+    """Permutation importance with cross-validation.
+
+    Parameters
+    ----------
+    X : pandas.DataFrame
+        Feature matrix.
+    y : pandas.Series
+        Target vector.
+    cv_splits : int, default 5
+        Number of folds.
+    n_repeats : int, default 5
+        Permutation repeats.
+    top_k : int | None, optional
+        Return only top k features.
+    sample_weight : numpy.ndarray | None, optional
+        Sample weights.
+    random_state : int | None, optional
+        Random seed.
+    """
+    if sample_weight is None:
+        sample_weight = make_balanced_sample_weights(y)
+
+    rng = np.random.default_rng(random_state)
+    Xw = X.copy()
+    Xw["__noise_uniform__"] = rng.uniform(0, 1, size=len(Xw))
+
+    cv = StratifiedKFold(cv_splits, shuffle=True, random_state=random_state)
+    base_model = LogisticRegression(max_iter=200, n_jobs=-1, random_state=random_state)
+
+    scores = pd.Series(0.0, index=Xw.columns)
+
+    for train_idx, test_idx in cv.split(Xw, y):
+        Xtr, ytr = Xw.iloc[train_idx], y.iloc[train_idx]
+        Xte, yte = Xw.iloc[test_idx], y.iloc[test_idx]
+        sw_train = sample_weight[train_idx]
+        sw_test = sample_weight[test_idx]
+        model = clone(base_model)
+        if supports_sample_weight(model):
+            model.fit(Xtr, ytr, sample_weight=sw_train)
+        else:
+            if hasattr(model, "get_params") and "class_weight" in model.get_params():
+                model.set_params(class_weight="balanced")
+            model.fit(Xtr, ytr)
+
+        scorer = make_scorer(roc_auc_score, needs_proba=True, sample_weight=sw_test)
+        result = permutation_importance(
+            model,
+            Xte,
+            yte,
+            scoring=scorer,
+            n_repeats=n_repeats,
+            random_state=random_state,
+        )
+        scores = scores.add(pd.Series(result.importances_mean, index=Xw.columns), fill_value=0)
+
+    scores /= cv_splits
+    scores = scores.abs().sort_values(ascending=False)
+    if top_k is not None:
+        scores = scores.iloc[:top_k]
+    return scores

--- a/vassoura/tests/test_importance.py
+++ b/vassoura/tests/test_importance.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from vassoura.process import basic_importance, advanced_importance
+
+
+def test_noise_uniform_present():
+    X = pd.DataFrame({"a": [1, 2, 3, 4], "b": [4, 3, 2, 1]})
+    y = pd.Series([0, 1, 0, 1])
+    imp = basic_importance(X, y)
+    assert "__noise_uniform__" in imp.index
+
+
+def test_method_switch_gain():
+    pytest.importorskip("xgboost")
+    X = pd.DataFrame(np.random.randn(20, 3), columns=list("abc"))
+    y = pd.Series([0, 1] * 10)
+    imp_gain = basic_importance(X, y, model="xgb", method="gain", random_state=0)
+    imp_coef = basic_importance(X, y, model="xgb", method="coef", random_state=0)
+    pd.testing.assert_series_equal(imp_gain, imp_coef)
+
+
+def test_weight_effect():
+    X = pd.DataFrame(np.random.randn(30, 2), columns=["a", "b"])
+    y = pd.Series([0] * 15 + [1] * 15)
+    w1 = np.where(y == 1, 1, 2)
+    w2 = np.where(y == 1, 2, 1)
+    imp1 = basic_importance(X, y, sample_weight=w1, random_state=0)
+    imp2 = basic_importance(X, y, sample_weight=w2, random_state=0)
+    assert not imp1.equals(imp2)
+
+
+def test_top_k():
+    X = pd.DataFrame(np.random.randn(50, 5), columns=list("abcde"))
+    y = pd.Series(np.random.randint(0, 2, size=50))
+    imp = basic_importance(X, y, top_k=3)
+    assert len(imp) == 3
+
+
+def test_advanced_runs_subset():
+    pytest.importorskip("shap")
+    X = pd.DataFrame(np.random.randn(100, 10), columns=[f"f{i}" for i in range(10)])
+    y = pd.Series(np.random.randint(0, 2, size=100))
+    imp = advanced_importance(X, y, n_trials=2, top_k=5, random_state=0)
+    assert len(imp) == 5
+
+
+def test_weights_consistency():
+    pytest.importorskip("shap")
+    X = pd.DataFrame(np.random.randn(100, 8), columns=[f"f{i}" for i in range(8)])
+    y = pd.Series(np.random.randint(0, 2, size=100))
+    imp1 = advanced_importance(X, y, n_trials=1, random_state=0)
+    w = np.where(y == 1, 2, 1)
+    imp2 = advanced_importance(X, y, n_trials=1, sample_weight=w, random_state=0)
+    assert not imp1.equals(imp2)
+
+
+def test_advanced_performance():
+    pytest.importorskip("shap")
+    X = pd.DataFrame(np.random.randn(1000, 100), columns=[f"f{i}" for i in range(100)])
+    y = pd.Series(np.random.randint(0, 2, size=1000))
+    advanced_importance(X, y, n_trials=1, top_k=10, random_state=0)

--- a/vassoura/utils/__init__.py
+++ b/vassoura/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions for modelling."""
 
 from .metrics import SCORERS
+from .weights import make_balanced_sample_weights
 
-__all__ = ["SCORERS"]
+__all__ = ["SCORERS", "make_balanced_sample_weights"]

--- a/vassoura/utils/weights.py
+++ b/vassoura/utils/weights.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+from sklearn.utils.class_weight import compute_sample_weight
+
+
+def make_balanced_sample_weights(y) -> np.ndarray:
+    """Return array of balanced sample weights.
+
+    Parameters
+    ----------
+    y : array-like
+        Target labels.
+
+    Returns
+    -------
+    numpy.ndarray
+        Computed sample weights.
+    """
+    return compute_sample_weight(class_weight="balanced", y=y)


### PR DESCRIPTION
## Summary
- implement basic, medium and advanced importance heuristics
- add balanced sample weight utility
- export new helpers
- document importance usage in README
- add tests for feature importance

## Testing
- `flake8 vassoura/process/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684901e4f3e4832183fd1592eacf6eb4