### PR TITLE
Implement Vassoura orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ scaler = DynamicScaler(strategy="auto")
 X_scaled = scaler.fit_transform(X_sampled)
 ```
 
+### Training with Vassoura
+
+```python
+from vassoura import Vassoura
+
+v = Vassoura(target_col="target")
+v.fit(df)
+preds = v.predict(df)
+```
+
 
 ### Example – Quick modelling
 

--- a/examples/0_quickstart.ipynb
+++ b/examples/0_quickstart.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Vassoura quickstart"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": "import pandas as pd\nfrom vassoura import Vassoura\n\ndf = pd.DataFrame({'a': [1,2,3], 'b':[0,1,0], 'target':[0,1,0]})\nv = Vassoura(target_col='target')\nv.fit(df)\nprint(v.get_feature_ranking())"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/vassoura/__init__.py
+++ b/vassoura/__init__.py
@@ -1,6 +1,7 @@
 """Vassoura – Unified feature-selection & reporting framework."""
 
 from .models import get as get_model, list_models
+from .core import Vassoura
 
-__all__ = ["get_model", "list_models"]
+__all__ = ["get_model", "list_models", "Vassoura"]
 __version__ = "0.0.1a0"

--- a/vassoura/core.py
+++ b/vassoura/core.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import joblib
+import pandas as pd
+from sklearn.model_selection import cross_validate
+from sklearn.pipeline import Pipeline
+
+from vassoura.logs import get_logger
+from vassoura.preprocessing import SampleManager, make_default_pipeline
+from vassoura.models import registry
+from vassoura.utils import SCORERS, split_dtypes, calculate_sample_weights
+from vassoura.validation import get_stratified_cv
+from vassoura.process.wrappers import import_heuristic
+
+
+class Vassoura:
+    def __init__(
+        self,
+        target_col: str,
+        *,
+        sampler_cfg: dict | None = None,
+        pipeline_cfg: dict | None = None,
+        model_name: str = "logistic_balanced",
+        heuristic: str = "basic",
+        cv_cfg: dict | None = None,
+        metrics: list[str] | None = None,
+        report: bool = False,
+        random_state: int | None = 42,
+        verbose: int = 1,
+    ) -> None:
+        self.target_col = target_col
+        self.sampler_cfg = sampler_cfg or {}
+        self.pipeline_cfg = pipeline_cfg or {}
+        self.model_name = model_name
+        self.heuristic = heuristic
+        self.cv_cfg = cv_cfg or {}
+        self.metrics = metrics or ["auc"]
+        self.report = report
+        self.random_state = random_state
+        self.verbose = verbose
+        self.logger = get_logger("Vassoura")
+        if verbose >= 2:
+            self.logger.setLevel("DEBUG")
+
+    # ------------------------------------------------------------------
+    def fit(self, df: pd.DataFrame) -> "Vassoura":
+        self.logger.info("=== Vassoura Fit Started ===")
+        X = df.drop(columns=[self.target_col])
+        y = df[self.target_col]
+
+        # Sampling
+        self.sampler_ = SampleManager(**self.sampler_cfg)
+        X_s, y_s = self.sampler_.fit_resample(X, y)
+
+        # Pipeline
+        num_cols, cat_cols = split_dtypes(X_s)
+        pipe_args = {
+            "scaler_strategy": self.pipeline_cfg.get(
+                "scaler_strategy", "auto"
+            ),
+            "encoder": self.pipeline_cfg.get("encoder", "woe"),
+        }
+        self.pipeline_ = make_default_pipeline(num_cols, cat_cols, **pipe_args)
+
+        # Model
+        ModelCls = registry.get(self.model_name)
+        self.model_ = ModelCls(random_state=self.random_state)
+        sample_weights = calculate_sample_weights(y_s)
+        self.logger.debug(
+            "Using sample weights – mean: %.3f", sample_weights.mean()
+        )
+
+        cv = get_stratified_cv(**self.cv_cfg)
+        scoring = {m: SCORERS[m] for m in self.metrics}
+
+        pipeline = Pipeline([("prep", self.pipeline_), ("clf", self.model_)])
+        try:
+            self.metrics_ = cross_validate(
+                pipeline,
+                X_s,
+                y_s,
+                cv=cv,
+                fit_params={"clf__sample_weight": sample_weights},
+                scoring=scoring,
+                return_train_score=False,
+            )
+            self._used_sample_weight = True
+        except TypeError:
+            self.logger.info(
+                "Sample weights not supported – falling back to class_weight"
+            )
+            if hasattr(self.model_, "get_params") and "class_weight" in (
+                self.model_.get_params()
+            ):
+                self.model_.set_params(class_weight="balanced")
+            self.metrics_ = cross_validate(
+                pipeline,
+                X_s,
+                y_s,
+                cv=cv,
+                scoring=scoring,
+                return_train_score=False,
+            )
+            self._used_sample_weight = False
+
+        # Fit final pipeline and model on full data
+        self.pipeline_.fit(X_s, y_s)
+        Xt_all = self.pipeline_.transform(X_s)
+        try:
+            self.model_.fit(Xt_all, y_s, sample_weight=sample_weights)
+        except TypeError:
+            if (
+                hasattr(self.model_, "get_params")
+                and "class_weight" in self.model_.get_params()
+            ):
+                self.model_.set_params(class_weight="balanced")
+            self.model_.fit(Xt_all, y_s)
+
+        # Importance heuristic
+        HeurCls = import_heuristic(self.heuristic)
+        self.heuristic_ = HeurCls(model=self.model_)
+        self.ranking_ = self.heuristic_.run(
+            X_s, y_s, sample_weight=sample_weights
+        )
+
+        if self.report:
+            self.export_report()
+
+        self.logger.info("=== Vassoura Fit Completed ===")
+        return self
+
+    # ------------------------------------------------------------------
+    def transform(self, df: pd.DataFrame) -> pd.DataFrame:
+        return self.pipeline_.transform(df)
+
+    # ------------------------------------------------------------------
+    def predict(self, df: pd.DataFrame):
+        Xt = self.pipeline_.transform(df)
+        return self.model_.predict(Xt)
+
+    # ------------------------------------------------------------------
+    def get_feature_ranking(self) -> pd.Series:
+        return self.ranking_.sort_values(ascending=False)
+
+    # ------------------------------------------------------------------
+    def export_report(self, path: str = "reports/report.html") -> None:
+        self.logger.warning("Report generation not implemented")
+
+    # ------------------------------------------------------------------
+    def save(self, path: str = "models/vassoura.pkl") -> None:
+        joblib.dump(self, path)
+
+    @classmethod
+    def load(cls, path: str) -> "Vassoura":
+        return joblib.load(path)

--- a/vassoura/process/wrappers.py
+++ b/vassoura/process/wrappers.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pandas as pd
+import numpy as np
+
+from .basic import basic_importance
+from .medium import medium_importance
+from .advanced import advanced_importance
+
+
+class BasicHeuristic:
+    """Wrapper around :func:`basic_importance`."""
+
+    def __init__(self, model=None):
+        self.model = model
+
+    def run(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        *,
+        sample_weight: np.ndarray | None = None,
+        random_state: int | None = 42,
+    ) -> pd.Series:
+        X_enc = pd.get_dummies(X, drop_first=False)
+        return basic_importance(
+            X_enc,
+            y,
+            model="logistic",
+            method="coef",
+            sample_weight=sample_weight,
+            random_state=random_state,
+        )
+
+
+class MediumHeuristic:
+    """Wrapper around :func:`medium_importance`."""
+
+    def __init__(self, model=None):
+        self.model = model
+
+    def run(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        *,
+        sample_weight: np.ndarray | None = None,
+        random_state: int | None = 42,
+    ) -> pd.Series:
+        return medium_importance(
+            X,
+            y,
+            sample_weight=sample_weight,
+            random_state=random_state,
+        )
+
+
+class AdvancedHeuristic:
+    """Wrapper around :func:`advanced_importance`."""
+
+    def __init__(self, model=None):
+        self.model = model
+
+    def run(
+        self,
+        X: pd.DataFrame,
+        y: pd.Series,
+        *,
+        sample_weight: np.ndarray | None = None,
+        random_state: int | None = 42,
+    ) -> pd.Series:
+        return advanced_importance(
+            X,
+            y,
+            sample_weight=sample_weight,
+            random_state=random_state,
+        )
+
+
+def import_heuristic(name: str):
+    mapping = {
+        "basic": BasicHeuristic,
+        "medium": MediumHeuristic,
+        "advanced": AdvancedHeuristic,
+    }
+    if name not in mapping:
+        raise ValueError(f"Unknown heuristic '{name}'")
+    return mapping[name]

--- a/vassoura/tests/test_core.py
+++ b/vassoura/tests/test_core.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from vassoura import Vassoura
+
+
+def _make_df() -> pd.DataFrame:
+    return pd.DataFrame({
+        "num": range(10),
+        "cat": ["a", "b"] * 5,
+        "target": [0, 1] * 5,
+    })
+
+
+def test_fit_runs_end_to_end_small_df():
+    df = _make_df()
+    v = Vassoura(target_col="target", random_state=0, verbose=0)
+    v.fit(df)
+    assert hasattr(v, "model_")
+
+
+def test_ranking_not_empty():
+    df = _make_df()
+    v = Vassoura(target_col="target", random_state=0, verbose=0)
+    v.fit(df)
+    ranking = v.get_feature_ranking()
+    assert len(ranking) > 0
+
+
+def test_metrics_contains_auc():
+    df = _make_df()
+    v = Vassoura(target_col="target", random_state=0, verbose=0)
+    v.fit(df)
+    assert any("auc" in k for k in v.metrics_.keys())
+
+
+def test_predict_after_fit():
+    df = _make_df()
+    v = Vassoura(target_col="target", random_state=0, verbose=0)
+    v.fit(df)
+    preds = v.predict(df.drop(columns=["target"]))
+    assert len(preds) == len(df)
+
+
+def test_sample_weight_fallback(monkeypatch, caplog):
+    class DummyEstimator:
+        name = "dummy"
+
+        def __init__(self, **kw):
+            pass
+
+        def fit(self, X, y):
+            self.fitted = True
+            return self
+
+        def predict(self, X):
+            return np.zeros(len(X))
+
+        def predict_proba(self, X):
+            return np.vstack([1 - self.predict(X), self.predict(X)]).T
+
+        def get_params(self, deep=True):
+            return {}
+
+    from vassoura.models import registry
+
+    monkeypatch.setitem(registry._registry, "dummy", DummyEstimator)
+
+    df = _make_df()
+    v = Vassoura(target_col="target", model_name="dummy", random_state=0, verbose=0)
+    with caplog.at_level("INFO"):
+        v.fit(df)
+    msgs = [r.message for r in caplog.records]
+    assert any("falling back" in m for m in msgs)

--- a/vassoura/utils/__init__.py
+++ b/vassoura/utils/__init__.py
@@ -2,5 +2,11 @@
 
 from .metrics import SCORERS
 from .weights import make_balanced_sample_weights
+from .data import split_dtypes, calculate_sample_weights
 
-__all__ = ["SCORERS", "make_balanced_sample_weights"]
+__all__ = [
+    "SCORERS",
+    "make_balanced_sample_weights",
+    "split_dtypes",
+    "calculate_sample_weights",
+]

--- a/vassoura/utils/data.py
+++ b/vassoura/utils/data.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from .weights import make_balanced_sample_weights
+
+__all__ = ["split_dtypes", "calculate_sample_weights"]
+
+
+def split_dtypes(df: pd.DataFrame) -> tuple[list[str], list[str]]:
+    """Return lists of numeric and categorical columns."""
+    num_cols = df.select_dtypes(include="number").columns.tolist()
+    cat_cols = [c for c in df.columns if c not in num_cols]
+    return num_cols, cat_cols
+
+
+def calculate_sample_weights(y) -> pd.Series:
+    """Wrapper for balanced sample weight calculation."""
+    return make_balanced_sample_weights(y)


### PR DESCRIPTION
## Summary
- implement main Vassoura orchestrator class
- support heuristic wrappers and utilities
- add quickstart notebook and README section
- export Vassoura in package init
- add comprehensive tests for core class

## Testing
- `flake8 vassoura/core.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849043c4c2c8321add1aaf657c37ae3