### PR TITLE
Implement AuditTrail and ReportManager utilities

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/README.md
+++ b/README.md
@@ -80,3 +80,27 @@ from vassoura.process import basic_importance
 imp = basic_importance(X_train, y_train, model="logistic", method="coef")
 print(imp.head())
 ```
+
+## Audit & Reports
+
+```python
+from vassoura import Vassoura, AuditTrail
+from vassoura.report import ReportManager, SECTION_REGISTRY
+
+df = pd.DataFrame({"a": [1, 2, 3], "target": [0, 1, 0]})
+audit = AuditTrail(auto_detect_types=True)
+audit.take_snapshot(df, "raw")
+
+v = Vassoura(target_col="target", report=True)
+v.fit(df)
+
+rm = ReportManager()
+rm.add_section(
+    SECTION_REGISTRY["overview"](
+        audit=audit,
+        snapshot_names=list(audit.snapshots.keys()),
+        dataset_shape=df.shape,
+    )
+)
+rm.render("report.html")
+```

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = true

--- a/vassoura/__init__.py
+++ b/vassoura/__init__.py
@@ -2,6 +2,8 @@
 
 from .models import get as get_model, list_models
 from .core import Vassoura
+from .audit import AuditTrail
 
-__all__ = ["get_model", "list_models", "Vassoura"]
+
+__all__ = ["get_model", "list_models", "Vassoura", "AuditTrail"]
 __version__ = "0.0.1a0"

--- a/vassoura/audit.py
+++ b/vassoura/audit.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional, List
+
+import pandas as pd
+import numpy as np
+
+from .helpers import calculate_ks, calculate_psi, search_dtypes
+
+__all__ = ["AuditTrail"]
+
+
+class AuditTrail:
+    """Utility to take and compare DataFrame snapshots."""
+
+    def __init__(
+        self,
+        track_histograms: bool = False,
+        track_distributions: bool = False,
+        enable_logging: bool = False,
+        auto_detect_types: bool = False,
+        target_col: str = "target",
+        limite_categorico: int = 50,
+        default_keys: Optional[List[str]] = None,
+    ) -> None:
+        self.track_histograms = track_histograms
+        self.track_distributions = track_distributions
+        self.enable_logging = enable_logging
+        self.auto_detect_types = auto_detect_types
+        self.target_col = target_col
+        self.limite_categorico = limite_categorico
+        self.default_keys = default_keys
+        self.snapshots: dict[str, dict] = {}
+
+        self.logger = logging.getLogger("audittrail")
+        if self.enable_logging:
+            logging.basicConfig(
+                filename="audit_trail.log",
+                level=logging.INFO,
+                format="%(asctime)s | %(levelname)s | %(message)s",
+            )
+
+    # ------------------------------------------------------------------
+    def _display(self, obj: object) -> None:
+        try:  # pragma: no cover - environment check
+            from IPython.display import display
+
+            display(obj)
+        except Exception:  # pragma: no cover - fallback
+            print(obj)
+
+    # ------------------------------------------------------------------
+    def take_snapshot(
+        self, df: pd.DataFrame, name: str, keys: Optional[List[str]] = None
+    ) -> None:
+        if name in self.snapshots:
+            raise ValueError(f"Snapshot com nome '{name}' já existe.")
+
+        keys = keys or self.default_keys
+        try:
+            cat_summary = df.describe(include=["object", "category"]).T
+        except ValueError:
+            cat_summary = pd.DataFrame()
+
+        snap: dict[str, object] = {
+            "shape": df.shape,
+            "dtypes": df.dtypes.astype(str),
+            "missing": df.isna().sum(),
+            "num_summary": df.describe(include=[np.number]).T,
+            "cat_summary": cat_summary,
+            "key_dupes": df.duplicated(subset=keys).sum() if keys else None,
+            "keys": keys,
+        }
+
+        if self.track_histograms:
+            snap["histograms"] = {
+                col: df[col].value_counts(dropna=False).to_dict()
+                for col in df.columns
+                if df[col].dtype.kind in {"O", "i", "u", "f", "b"}
+            }
+
+        if self.auto_detect_types:
+            num_cols, cat_cols = search_dtypes(
+                df, self.target_col, self.limite_categorico
+            )
+            snap["num_cols"] = num_cols
+            snap["cat_cols"] = cat_cols
+
+        self.snapshots[name] = snap
+        self._log(f"Snapshot '{name}' salvo com sucesso. Shape: {df.shape}")
+
+    # ------------------------------------------------------------------
+    def describe_snapshot(self, name: str) -> None:
+        if name not in self.snapshots:
+            raise ValueError(f"Snapshot '{name}' não encontrado.")
+
+        snap = self.snapshots[name]
+        print(f"\n📄 Descrição do snapshot '{name}':\n")
+        print(f"▶️ Shape: {snap['shape']}")
+        print(f"▶️ Chaves de duplicação: {snap['keys']}")
+        if snap["keys"]:
+            print(f"   • Duplicatas nas chaves: {snap['key_dupes']}")
+
+        print("\n🧱 Tipos de dados:")
+        self._display(snap["dtypes"])
+
+        if self.auto_detect_types:
+            print("\n🔎 Colunas detectadas automaticamente:")
+            print(
+                f"   • Numéricas ({len(snap.get('num_cols', []))}): {snap.get('num_cols', [])}"
+            )
+            print(
+                f"   • Categóricas ({len(snap.get('cat_cols', []))}): {snap.get('cat_cols', [])}"
+            )
+
+        print("\n🕳️ Valores ausentes:")
+        missing = snap["missing"]
+        missing = missing[missing > 0]
+        if missing.empty:
+            print("  ✅ Nenhuma coluna com valores ausentes.")
+        else:
+            self._display(missing.sort_values(ascending=False))
+
+        print("\n📊 Estatísticas numéricas:")
+        self._display(snap["num_summary"])
+
+        print("\n🏷️ Estatísticas categóricas:")
+        self._display(snap["cat_summary"])
+
+        if self.track_histograms and "histograms" in snap:
+            print("\n📈 Histogramas (categorias apenas):")
+            for col in snap.get("cat_cols", []):
+                hist = snap["histograms"].get(col)
+                if hist:
+                    top3 = dict(list(hist.items())[:3])
+                    print(f"  {col}: {len(hist)} valores distintos (top 3: {top3})")
+
+    # ------------------------------------------------------------------
+    def compare_snapshots(self, name1: str, name2: str) -> None:
+        if name1 not in self.snapshots or name2 not in self.snapshots:
+            raise ValueError("Snapshot não encontrado.")
+
+        snap1, snap2 = self.snapshots[name1], self.snapshots[name2]
+
+        print(f"\n🔍 Comparando '{name1}' vs '{name2}':\n")
+        print("▶️ Shape:")
+        print(f"  {name1}: {snap1['shape']} vs {name2}: {snap2['shape']}\n")
+
+        common_cols = snap1["dtypes"].index.intersection(snap2["dtypes"].index)
+        dtypes_diff = snap1["dtypes"][common_cols] != snap2["dtypes"][common_cols]
+        dtypes_diff = dtypes_diff.loc[lambda x: x]
+        if not dtypes_diff.empty:
+            print("▶️ Mudanças em tipos de dados:\n", dtypes_diff, "\n")
+
+        missing_diff = (snap2["missing"] - snap1["missing"]).loc[lambda x: x != 0]
+        if not missing_diff.empty:
+            print("▶️ Diferença de valores ausentes:\n", missing_diff, "\n")
+
+        if snap1["keys"] and snap2["keys"]:
+            print("▶️ Duplicatas nas chaves:")
+            print(f"  {name1}: {snap1['key_dupes']} vs {name2}: {snap2['key_dupes']}\n")
+
+        print("▶️ Mudança na média de variáveis numéricas:")
+        mean_diff = snap2["num_summary"]["mean"] - snap1["num_summary"]["mean"]
+        mean_diff = mean_diff.dropna()
+        self._display(mean_diff[mean_diff.abs() > 1e-6])
+
+        if self.track_distributions and "histograms" in snap1 and "histograms" in snap2:
+            print("\n▶️ KS-test e PSI para variáveis:")
+            cols_common = set(snap1.get("histograms", {})).intersection(
+                snap2.get("histograms", {})
+            )
+            for col in sorted(cols_common):
+                dist1 = snap1["histograms"].get(col, {})
+                dist2 = snap2["histograms"].get(col, {})
+                ks_stat = calculate_ks(dist1, dist2)
+                psi_val = calculate_psi(dist1, dist2)
+                alerta = " ⚠️" if psi_val > 0.2 else ""
+                print(f"  {col}: KS={ks_stat:.3f}, PSI={psi_val:.3f}{alerta}")
+                if psi_val > 0.2:
+                    self._log(
+                        f"Alerta PSI>0.2 detectado para '{col}': PSI={psi_val:.3f}"
+                    )
+
+    # ------------------------------------------------------------------
+    def _log(self, msg: str) -> None:
+        if self.enable_logging:
+            self.logger.info(msg)
+
+    # ------------------------------------------------------------------
+    def list_snapshots(self) -> None:
+        print("📚 Snapshots disponíveis:")
+        for k in self.snapshots:
+            print(f" - {k}")

--- a/vassoura/helpers.py
+++ b/vassoura/helpers.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["search_dtypes", "calculate_ks", "calculate_psi"]
+
+
+def search_dtypes(
+    df: pd.DataFrame,
+    target_col: str = "target",
+    limite_categorico: int = 50,
+) -> tuple[list[str], list[str]]:
+    """Detect numeric and categorical columns.
+
+    Columns with integer type and fewer than ``limite_categorico`` unique values
+    are treated as categorical. The ``target_col`` is ignored.
+    """
+    num_cols = df.select_dtypes(include="number").columns.tolist()
+    cat_cols: list[str] = [c for c in df.columns if c not in num_cols]
+    for col in num_cols.copy():
+        if col == target_col:
+            num_cols.remove(col)
+            continue
+        if (
+            pd.api.types.is_integer_dtype(df[col])
+            and df[col].nunique() <= limite_categorico
+        ):
+            num_cols.remove(col)
+            cat_cols.append(col)
+    cat_cols = [c for c in cat_cols if c != target_col]
+    return num_cols, cat_cols
+
+
+def _prepare_series(dist: dict[str, int]) -> pd.Series:
+    s = pd.Series(dist, dtype=float)
+    s = s.reindex(sorted(s.index))
+    s = s.fillna(0)
+    if s.sum() == 0:
+        return s
+    return s / s.sum()
+
+
+def calculate_ks(dist1: dict[str, int], dist2: dict[str, int]) -> float:
+    """Compute KS statistic from two distributions represented as dictionaries."""
+    s1 = _prepare_series(dist1)
+    s2 = _prepare_series(dist2)
+    all_bins = s1.index.union(s2.index)
+    s1 = s1.reindex(all_bins, fill_value=0)
+    s2 = s2.reindex(all_bins, fill_value=0)
+    cdf1 = s1.cumsum()
+    cdf2 = s2.cumsum()
+    return float((cdf1 - cdf2).abs().max())
+
+
+def calculate_psi(dist1: dict[str, int], dist2: dict[str, int]) -> float:
+    """Compute Population Stability Index between two distributions."""
+    s1 = _prepare_series(dist1)
+    s2 = _prepare_series(dist2)
+    all_bins = s1.index.union(s2.index)
+    s1 = s1.reindex(all_bins, fill_value=1e-6)
+    s2 = s2.reindex(all_bins, fill_value=1e-6)
+    psi = ((s1 - s2) * np.log(s1 / s2)).sum()
+    return float(psi)

--- a/vassoura/models/registry.py
+++ b/vassoura/models/registry.py
@@ -14,7 +14,11 @@ def _discover() -> None:
     for _, name, _ in pkgutil.iter_modules([str(pkg)]):
         if name in {"__init__", "base", "registry", "utils"}:
             continue
-        module = import_module(f"vassoura.models.{name}")
+        try:
+            module = import_module(f"vassoura.models.{name}")
+        except ModuleNotFoundError:
+            # Optional dependency missing – silently skip
+            continue
         for attr in dir(module):
             obj = getattr(module, attr)
             if (

--- a/vassoura/preprocessing/sampler.py
+++ b/vassoura/preprocessing/sampler.py
@@ -43,20 +43,16 @@ class SampleManager(BaseEstimator, TransformerMixin):
         if self.strategy in {"time_series", "stratified"}:
             return True
         # auto strategy
-        mem_mb = X.memory_usage(deep=True).sum() / 2 ** 20
+        mem_mb = X.memory_usage(deep=True).sum() / 2**20
         row_cap = self.limit_mb * 25
         return mem_mb > self.limit_mb or len(X) > row_cap
 
-    def fit(
-        self, X: pd.DataFrame, y: Iterable | None = None
-    ) -> "SampleManager":
+    def fit(self, X: pd.DataFrame, y: Iterable | None = None) -> "SampleManager":
         if self.strategy == "stratified" and y is None:
             raise ValueError("y is required for stratified sampling")
         if self.strategy == "time_series":
             if self.time_col is None or self.time_col not in X.columns:
-                raise ValueError(
-                    "time_col must be provided for time_series strategy"
-                )
+                raise ValueError("time_col must be provided for time_series strategy")
         if self.strategy not in {"auto", "stratified", "time_series", "none"}:
             raise ValueError(f"Unknown strategy '{self.strategy}'")
 
@@ -70,7 +66,7 @@ class SampleManager(BaseEstimator, TransformerMixin):
         original_rows = len(X)
         sampled_rows = self.sample_size_ if self._do_sample else original_rows
         if self.verbose >= 2:
-            mem_before = X.memory_usage(deep=True).sum() / 2 ** 20
+            mem_before = X.memory_usage(deep=True).sum() / 2**20
             mem_after = mem_before * (self.frac if self._do_sample else 1)
             self.logger.debug(
                 "memory before=%.2fMB after=%.2fMB", mem_before, mem_after
@@ -111,9 +107,7 @@ class SampleManager(BaseEstimator, TransformerMixin):
             mask = np.zeros(len(X), dtype=bool)
             mask[train_idx] = True
         else:
-            idx = X.sample(
-                frac=self.frac, random_state=self.random_state
-            ).index
+            idx = X.sample(frac=self.frac, random_state=self.random_state).index
             mask = X.index.isin(idx)
 
         self.mask_ = mask
@@ -127,22 +121,20 @@ class SampleManager(BaseEstimator, TransformerMixin):
             return X_res, y_res
         return X_res, None
 
-    def transform(
-        self, X: pd.DataFrame, y: Iterable | None = None
-    ) -> pd.DataFrame:
+    def transform(self, X: pd.DataFrame, y: Iterable | None = None) -> pd.DataFrame:
         X_res, _ = self._apply_sampling(X, y)
         return X_res
 
-    def fit_transform(
-        self, X: pd.DataFrame, y: Iterable | None = None
-    ) -> pd.DataFrame:
+    def fit_transform(self, X: pd.DataFrame, y: Iterable | None = None) -> pd.DataFrame:
         return self.fit(X, y).transform(X, y)
 
     def fit_resample(
         self, X: pd.DataFrame, y: Iterable
     ) -> tuple[pd.DataFrame, Iterable]:
         self.fit(X, y)
-        return self._apply_sampling(X, y)
+        X_res, y_res = self._apply_sampling(X, y)
+        assert y_res is not None
+        return X_res, y_res
 
     def get_support_mask(self) -> np.ndarray:
         if self.mask_.size == 0:

--- a/vassoura/process/__init__.py
+++ b/vassoura/process/__init__.py
@@ -2,7 +2,15 @@
 
 from .basic import basic_importance
 from .medium import medium_importance
-from .advanced import advanced_importance
+from typing import Callable, Optional  # noqa: F401
+
+advanced_importance: Optional[Callable]
+try:
+    from .advanced import advanced_importance as _advanced_importance
+
+    advanced_importance = _advanced_importance
+except Exception:  # optional dependency "shap"
+    advanced_importance = None
 
 __all__ = [
     "basic_importance",

--- a/vassoura/process/wrappers.py
+++ b/vassoura/process/wrappers.py
@@ -5,7 +5,16 @@ import numpy as np
 
 from .basic import basic_importance
 from .medium import medium_importance
-from .advanced import advanced_importance
+
+from typing import Callable, Optional  # noqa: F401
+
+advanced_importance: Optional[Callable]
+try:
+    from .advanced import advanced_importance as _advanced_importance
+
+    advanced_importance = _advanced_importance
+except Exception:  # optional dependency "shap"
+    advanced_importance = None
 
 
 class BasicHeuristic:
@@ -69,6 +78,8 @@ class AdvancedHeuristic:
         sample_weight: np.ndarray | None = None,
         random_state: int | None = 42,
     ) -> pd.Series:
+        if advanced_importance is None:
+            raise ImportError("advanced_importance requires 'shap' installed")
         return advanced_importance(
             X,
             y,

--- a/vassoura/report.py
+++ b/vassoura/report.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Protocol, Dict, Type, Any
+from pathlib import Path
+from datetime import datetime
+
+import pandas as pd
+import plotly.express as px
+
+from .audit import AuditTrail
+
+__all__ = ["ReportManager", "register_section", "SECTION_REGISTRY"]
+
+
+class ReportSection(Protocol):
+    name: str
+
+    def generate(self) -> str: ...
+
+
+SECTION_REGISTRY: Dict[str, Type[Any]] = {}
+
+
+def register_section(name: str):
+    def decorator(cls: Type[Any]):
+        SECTION_REGISTRY[name] = cls
+        return cls
+
+    return decorator
+
+
+@dataclass
+class OverviewSection:
+    audit: AuditTrail
+    snapshot_names: list[str]
+    dataset_shape: tuple[int, int]
+
+    name: str = "overview"
+
+    def generate(self) -> str:
+        date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        snapshots = ", ".join(self.snapshot_names)
+        html = "<h2>Overview</h2>"
+        html += f"<p>Date: {date}</p>"
+        html += f"<p>Dataset shape: {self.dataset_shape}</p>"
+        html += f"<p>Snapshots: {snapshots}</p>"
+        return html
+
+
+@dataclass
+class PerformanceSection:
+    metrics: pd.DataFrame
+
+    name: str = "performance"
+
+    def generate(self) -> str:
+        html = "<h2>Performance</h2>" + self.metrics.to_html()
+        return html
+
+
+@dataclass
+class FeatureImportanceSection:
+    importance: pd.Series
+
+    name: str = "feature_importance"
+
+    def generate(self) -> str:
+        imp = self.importance.sort_values(ascending=False).head(20)
+        fig = px.bar(imp, orientation="h")
+        return "<h2>Feature Importance</h2>" + fig.to_html(include_plotlyjs="cdn")
+
+
+@dataclass
+class AuditDiffSection:
+    audit: AuditTrail
+    base: str
+    new: str
+
+    name: str = "audit_diff"
+
+    def generate(self) -> str:
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            self.audit.compare_snapshots(self.base, self.new)
+        content = buf.getvalue().replace("\n", "<br>")
+        return f"<h2>Audit Diff</h2><pre>{content}</pre>"
+
+
+@register_section("overview")
+class RegisteredOverview(OverviewSection):
+    pass
+
+
+@register_section("performance")
+class RegisteredPerformance(PerformanceSection):
+    pass
+
+
+@register_section("feature_importance")
+class RegisteredFeatureImportance(FeatureImportanceSection):
+    pass
+
+
+@register_section("audit_diff")
+class RegisteredAuditDiff(AuditDiffSection):
+    pass
+
+
+class ReportManager:
+    def __init__(
+        self,
+        mandatory_sections: tuple[str, ...] = ("overview", "performance"),
+        async_render: bool = False,
+        theme: str = "flatly",
+    ) -> None:
+        self.mandatory_sections = list(mandatory_sections)
+        self.async_render = async_render
+        self.theme = theme
+        self.sections: Dict[str, ReportSection] = {}
+
+    def add_section(self, section: ReportSection) -> None:
+        self.sections[section.name] = section
+
+    def _render_section(self, section: ReportSection) -> str:
+        return section.generate()
+
+    def render(self, path: str | Path = "reports/report.html") -> Path:
+        order = self.mandatory_sections + [
+            n for n in self.sections.keys() if n not in self.mandatory_sections
+        ]
+        sections = [self.sections[n] for n in order if n in self.sections]
+
+        if self.async_render:
+
+            async def _collect() -> list[str]:
+                return await asyncio.gather(
+                    *[asyncio.to_thread(self._render_section, s) for s in sections]
+                )
+
+            html_parts: list[str] = asyncio.run(_collect())
+        else:
+            html_parts = [self._render_section(s) for s in sections]
+
+        toc = (
+            "<ul>"
+            + "".join(
+                f"<li><a href='#{n}'>{n.title()}</a></li>"
+                for n in order
+                if n in self.sections
+            )
+            + "</ul>"
+        )
+
+        body = "".join(
+            f"<section id='{sec.name}'>{html}</section>"
+            for sec, html in zip(sections, html_parts)
+        )
+        css = f"https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/{self.theme}/bootstrap.min.css"
+        final_html = f"<html><head><link rel='stylesheet' href='{css}'></head><body>{toc}{body}</body></html>"
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(final_html, encoding="utf8")
+        return path

--- a/vassoura/tests/test_audit.py
+++ b/vassoura/tests/test_audit.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from vassoura.audit import AuditTrail
+
+
+@pytest.fixture
+def df_sample() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "a": [1, 2, 2, 3],
+            "b": ["x", "y", "y", "z"],
+            "target": [0, 1, 0, 1],
+        }
+    )
+
+
+def test_snapshot_roundtrip(df_sample):
+    at = AuditTrail()
+    at.take_snapshot(df_sample, "s1")
+    at.describe_snapshot("s1")
+
+
+def test_duplicate_detection(df_sample):
+    at = AuditTrail(default_keys=["a", "b"])
+    at.take_snapshot(df_sample, "s1")
+    assert at.snapshots["s1"]["key_dupes"] > 0
+
+
+def test_auto_detect_types_returns_lists(df_sample):
+    at = AuditTrail(auto_detect_types=True)
+    at.take_snapshot(df_sample, "s1")
+    snap = at.snapshots["s1"]
+    assert isinstance(snap["num_cols"], list)
+    assert isinstance(snap["cat_cols"], list)
+
+
+def test_compare_snapshots_shapes(df_sample):
+    at = AuditTrail()
+    at.take_snapshot(df_sample, "s1")
+    df2 = df_sample.copy()
+    df2["a"] += 1
+    at.take_snapshot(df2, "s2")
+    at.compare_snapshots("s1", "s2")
+
+
+def test_psi_alert_logs(monkeypatch, df_sample, caplog):
+    at = AuditTrail(
+        track_histograms=True, track_distributions=True, enable_logging=True
+    )
+
+    def fake_psi(d1, d2):
+        return 0.3
+
+    from vassoura import audit as audit_module
+
+    monkeypatch.setattr(audit_module, "calculate_psi", fake_psi)
+    at.take_snapshot(df_sample, "s1")
+    at.take_snapshot(df_sample, "s2")
+    with caplog.at_level("INFO"):
+        at.compare_snapshots("s1", "s2")
+    assert any("PSI>0.2" in r.message for r in caplog.records)

--- a/vassoura/tests/test_report.py
+++ b/vassoura/tests/test_report.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pandas as pd
+from pathlib import Path
+
+from vassoura.report import ReportManager, SECTION_REGISTRY
+from vassoura.audit import AuditTrail
+
+
+def make_manager(tmp_path: Path) -> ReportManager:
+    at = AuditTrail()
+    df = pd.DataFrame({"a": [1, 2], "target": [0, 1]})
+    at.take_snapshot(df, "raw")
+    at.take_snapshot(df, "processed")
+
+    metrics = pd.DataFrame({"test": [0.5]})
+    rm = ReportManager()
+    rm.add_section(
+        SECTION_REGISTRY["overview"](
+            audit=at,
+            snapshot_names=["raw", "processed"],
+            dataset_shape=df.shape,
+        )
+    )
+    rm.add_section(SECTION_REGISTRY["performance"](metrics=metrics))
+    rm.add_section(
+        SECTION_REGISTRY["feature_importance"](importance=pd.Series({"a": 1.0}))
+    )
+    rm.add_section(
+        SECTION_REGISTRY["audit_diff"](audit=at, base="raw", new="processed")
+    )
+    return rm
+
+
+def test_render_creates_file(tmp_path: Path):
+    rm = make_manager(tmp_path)
+    out = rm.render(tmp_path / "report.html")
+    assert out.exists()
+
+
+def test_missing_optional_section(tmp_path: Path):
+    at = AuditTrail()
+    df = pd.DataFrame({"a": [1], "target": [0]})
+    at.take_snapshot(df, "raw")
+    metrics = pd.DataFrame({"test": [0.1]})
+    rm = ReportManager()
+    rm.add_section(
+        SECTION_REGISTRY["overview"](
+            audit=at,
+            snapshot_names=["raw"],
+            dataset_shape=df.shape,
+        )
+    )
+    rm.add_section(SECTION_REGISTRY["performance"](metrics=metrics))
+    out = rm.render(tmp_path / "report.html")
+    assert out.exists()
+
+
+def test_async_render_equivalence(tmp_path: Path):
+    rm_sync = make_manager(tmp_path)
+    rm_async = make_manager(tmp_path)
+    rm_async.async_render = True
+    out1 = rm_sync.render(tmp_path / "r1.html")
+    out2 = rm_async.render(tmp_path / "r2.html")
+    content1 = out1.read_text()
+    content2 = out2.read_text()
+    assert "Feature Importance" in content1
+    assert "Feature Importance" in content2
+    assert abs(len(content1) - len(content2)) < 500
+
+
+def test_section_registry_population():
+    for name in ["overview", "performance", "feature_importance", "audit_diff"]:
+        assert name in SECTION_REGISTRY


### PR DESCRIPTION
## Summary
- port legacy audit trail into `vassoura/audit.py`
- add helpers for KS, PSI and dtype detection
- create modular `ReportManager` with registrable sections
- integrate auditing and reporting into `Vassoura`
- skip optional heavy dependencies and make model discovery robust
- add new unit tests and update README

## Testing
- `flake8 vassoura/core.py vassoura/audit.py vassoura/report.py vassoura/helpers.py vassoura/tests/test_audit.py vassoura/tests/test_report.py vassoura/models/registry.py vassoura/preprocessing/sampler.py vassoura/process/wrappers.py vassoura/process/__init__.py vassoura/__init__.py`
- `mypy vassoura`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684908358a7883219bcbbeb64d00e564