### PR TITLE
Handle column categories and fix scoring

### DIFF
--- a/src/vassoura/models/lgb.py
+++ b/src/vassoura/models/lgb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import lightgbm as lgb
+from sklearn.base import BaseEstimator, ClassifierMixin
 
 from vassoura.logs import get_logger
 
@@ -8,10 +9,11 @@ from .base import WrapperBase
 from .utils import make_sample_weights, supports_sample_weight
 
 
-class LightGBMWrapper(WrapperBase):
+class LightGBMWrapper(WrapperBase, BaseEstimator, ClassifierMixin):
     """LightGBM classifier wrapper with balanced weights."""
 
     name = "lightgbm_balanced"
+    _estimator_type = "classifier"
 
     def __init__(self, **params) -> None:
         defaults = dict(

--- a/src/vassoura/models/lr.py
+++ b/src/vassoura/models/lr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.linear_model import LogisticRegression
 
 from vassoura.logs import get_logger
@@ -8,10 +9,11 @@ from .base import WrapperBase
 from .utils import make_sample_weights, supports_sample_weight
 
 
-class LogisticRegressionWrapper(WrapperBase):
+class LogisticRegressionWrapper(WrapperBase, BaseEstimator, ClassifierMixin):
     """Logistic Regression with balanced sampling."""
 
     name = "logistic_balanced"
+    _estimator_type = "classifier"
 
     def __init__(self, **params) -> None:
         defaults = dict(

--- a/src/vassoura/models/xgb.py
+++ b/src/vassoura/models/xgb.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import xgboost as xgb
+from sklearn.base import BaseEstimator, ClassifierMixin
 
 from vassoura.logs import get_logger
 
@@ -8,10 +9,11 @@ from .base import WrapperBase
 from .utils import make_sample_weights, supports_sample_weight
 
 
-class XGBoostWrapper(WrapperBase):
+class XGBoostWrapper(WrapperBase, BaseEstimator, ClassifierMixin):
     """XGBoost classifier wrapper with balanced weights."""
 
     name = "xgboost_balanced"
+    _estimator_type = "classifier"
 
     def __init__(self, **params) -> None:
         defaults = dict(

--- a/src/vassoura/report.py
+++ b/src/vassoura/report.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import Protocol, Dict, Type, Any
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Protocol, Type
 
 import pandas as pd
 import plotly.express as px
@@ -36,6 +36,10 @@ class OverviewSection:
     audit: AuditTrail
     snapshot_names: list[str]
     dataset_shape: tuple[int, int]
+    id_cols: list[str] | None = None
+    date_cols: list[str] | None = None
+    ignore_cols: list[str] | None = None
+    keep_cols: list[str] | None = None
 
     name: str = "overview"
 
@@ -46,6 +50,10 @@ class OverviewSection:
         html += f"<p>Date: {date}</p>"
         html += f"<p>Dataset shape: {self.dataset_shape}</p>"
         html += f"<p>Snapshots: {snapshots}</p>"
+        html += f"<p>ID columns: {', '.join(self.id_cols or [])}</p>"
+        html += f"<p>Date columns: {', '.join(self.date_cols or [])}</p>"
+        html += f"<p>Ignored columns: {', '.join(self.ignore_cols or [])}</p>"
+        html += f"<p>Keep columns: {', '.join(self.keep_cols or [])}</p>"
         return html
 
 

--- a/src/vassoura/tests/test_models.py
+++ b/src/vassoura/tests/test_models.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 import pytest
-
 from sklearn.linear_model import LogisticRegression
 
 from vassoura.models import get, list_models
@@ -58,6 +57,7 @@ def test_class_weight_fallback(monkeypatch):
 
         def fit(self, X, y):
             self.fitted = True
+
     from vassoura.models.lr import LogisticRegressionWrapper
 
     wrapper = LogisticRegressionWrapper()
@@ -72,3 +72,14 @@ def test_registry_lookup():
     from vassoura.models.lr import LogisticRegressionWrapper
 
     assert Model is LogisticRegressionWrapper
+
+
+def test_wrappers_classifier_flag():
+    for name in list_models():
+        Model = get(name)
+        if "xgboost" in name:
+            pytest.importorskip("xgboost")
+        if "lightgbm" in name:
+            pytest.importorskip("lightgbm")
+        est = Model()
+        assert getattr(est, "_estimator_type", None) == "classifier"


### PR DESCRIPTION
## Summary
- add explicit id/date/ignore/keep parameters
- convert datetime columns before modelling
- mark wrappers as classifiers and filter metrics accordingly
- expose column groups in report overview
- test datetime handling, keep_cols behaviour and classifier flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a36745e78832184829b278f9bd671