### PR TITLE
Fix missing classes_ in LogisticRegressionWrapper

### DIFF
--- a/src/vassoura/models/base.py
+++ b/src/vassoura/models/base.py
@@ -33,3 +33,9 @@ class WrapperBase(ABC):
         if hasattr(self.model, "set_params"):
             self.model.set_params(**params)
         return self
+
+    def __getattr__(self, item):
+        """Delegate attribute access to the underlying model if possible."""
+        if item == "model":
+            raise AttributeError(item)
+        return getattr(self.model, item)

--- a/src/vassoura/models/lr.py
+++ b/src/vassoura/models/lr.py
@@ -37,6 +37,9 @@ class LogisticRegressionWrapper(WrapperBase, BaseEstimator, ClassifierMixin):
             if "class_weight" in self.model.get_params():
                 self.model.set_params(class_weight="balanced")
             self.model.fit(X, y)
+        # expose learned classes for sklearn compatibility
+        if hasattr(self.model, "classes_"):
+            self.classes_ = self.model.classes_
         self.logger.debug(
             "[ModelWrapper] model='%s' | params=%d | sample_weight=%s",
             self.name,


### PR DESCRIPTION
## Summary
- delegate attribute access from wrappers to the underlying estimator
- expose `classes_` after fitting `LogisticRegressionWrapper`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3dd40d508321b290771a9b474a23